### PR TITLE
Implement retry on technical failure for reviewer node (issue #9)

### DIFF
--- a/src/copium_loop/copium_loop.py
+++ b/src/copium_loop/copium_loop.py
@@ -67,7 +67,12 @@ class WorkflowManager:
         workflow.add_conditional_edges(
             "reviewer",
             should_continue_from_review,
-            {"pr_creator": "pr_creator", "coder": "coder", END: END},
+            {
+                "pr_creator": "pr_creator",
+                "coder": "coder",
+                "reviewer": "reviewer",
+                END: END,
+            },
         )
 
         workflow.add_conditional_edges(

--- a/src/copium_loop/nodes/conditionals.py
+++ b/src/copium_loop/nodes/conditionals.py
@@ -22,7 +22,8 @@ def should_continue_from_test(state: AgentState) -> str:
 
 def should_continue_from_review(state: AgentState) -> str:
     telemetry = get_telemetry()
-    if state.get("review_status") == "approved":
+    status = state.get("review_status")
+    if status == "approved":
         telemetry.log_status("reviewer", "success")
         return "pr_creator"
 
@@ -31,6 +32,9 @@ def should_continue_from_review(state: AgentState) -> str:
         telemetry.log_status("reviewer", "error")
         telemetry.log_workflow_status("failed")
         return END
+
+    if status == "error":
+        return "reviewer"
 
     return "coder"
 

--- a/test/nodes/test_conditionals.py
+++ b/test/nodes/test_conditionals.py
@@ -44,6 +44,28 @@ class TestConditionalLogic:
             == "coder"
         )
 
+    def test_should_continue_from_review_on_error(self):
+        """Test transition from review to reviewer on error."""
+        assert (
+            should_continue_from_review({"review_status": "error", "retry_count": 0})
+            == "reviewer"
+        )
+
+    def test_should_continue_from_review_max_retries(self):
+        """Test END transition on max retries from reviewer."""
+        assert (
+            should_continue_from_review(
+                {"review_status": "rejected", "retry_count": MAX_RETRIES + 1}
+            )
+            == END
+        )
+        assert (
+            should_continue_from_review(
+                {"review_status": "error", "retry_count": MAX_RETRIES + 1}
+            )
+            == END
+        )
+
     def test_should_continue_from_pr_creator_on_success(self):
         """Test END transition on PR creation success."""
         assert should_continue_from_pr_creator({"review_status": "pr_created"}) == END
@@ -64,4 +86,13 @@ class TestConditionalLogic:
                 {"review_status": "pr_failed", "retry_count": 0}
             )
             == "coder"
+        )
+
+    def test_should_continue_from_pr_creator_max_retries(self):
+        """Test END transition on max retries from pr_creator."""
+        assert (
+            should_continue_from_pr_creator(
+                {"review_status": "pr_failed", "retry_count": MAX_RETRIES + 1}
+            )
+            == END
         )


### PR DESCRIPTION
- Update reviewer node to return 'error' status on exception or missing verdict.
- Update conditional logic to retry reviewer node on 'error' status.
- Add 'reviewer' to 'reviewer' transition in LangGraph.
- Add tests for new status and routing logic.

Closes https://github.com/gfxblit/copium-loop/issues/9