### PR TITLE
feat: remove stale sessions from dashboard when .jsonl files are deleted

### DIFF
--- a/src/copium_loop/copium_loop.py
+++ b/src/copium_loop/copium_loop.py
@@ -43,9 +43,7 @@ class WorkflowManager:
 
         async def wrapper(state: AgentState):
             try:
-                return await asyncio.wait_for(
-                    node_func(state), timeout=NODE_TIMEOUT
-                )
+                return await asyncio.wait_for(node_func(state), timeout=NODE_TIMEOUT)
             except asyncio.TimeoutError:
                 msg = f"Node '{node_name}' timed out after {NODE_TIMEOUT}s."
                 print(f"\n[TIMEOUT] {msg}")

--- a/src/copium_loop/ui.py
+++ b/src/copium_loop/ui.py
@@ -447,6 +447,14 @@ class Dashboard:
     def update_from_logs(self):
         """Reads .jsonl files and updates session states."""
         log_files = sorted(self.log_dir.glob("*.jsonl"), key=os.path.getmtime)
+        active_sids = {f.stem for f in log_files}
+
+        # Remove stale sessions
+        stale_sids = [sid for sid in self.sessions if sid not in active_sids]
+        for sid in stale_sids:
+            del self.sessions[sid]
+            if sid in self.log_offsets:
+                del self.log_offsets[sid]
 
         for target_file in log_files:
             sid = target_file.stem

--- a/test/test_issue14_node_timeout.py
+++ b/test/test_issue14_node_timeout.py
@@ -11,6 +11,7 @@ async def test_node_exceeds_inactivity_but_below_node_timeout():
     """
     Test that a node can run longer than INACTIVITY_TIMEOUT if it's below NODE_TIMEOUT.
     """
+
     async def mid_length_node(_state):
         # Sleep for longer than INACTIVITY_TIMEOUT but less than what NODE_TIMEOUT will be
         # We'll mock these to small values for speed
@@ -38,6 +39,7 @@ async def test_node_exceeds_node_timeout():
     """
     Test that a node still times out if it exceeds NODE_TIMEOUT.
     """
+
     async def very_slow_node(_state):
         await asyncio.sleep(1.0)
         return {"test_output": "PASS"}
@@ -47,7 +49,6 @@ async def test_node_exceeds_node_timeout():
     # We want it to timeout at NODE_TIMEOUT (0.5s)
 
     with patch("copium_loop.copium_loop.NODE_TIMEOUT", 0.5):
-
         wrapped = manager._wrap_node("very_slow_node", very_slow_node)
         state = {"retry_count": 0}
         result = await wrapped(state)

--- a/test/test_issue15_fixes.py
+++ b/test/test_issue15_fixes.py
@@ -1,4 +1,3 @@
-
 import asyncio
 import contextlib
 import os
@@ -53,7 +52,7 @@ except KeyboardInterrupt:
 
     async def mock_subprocess_exec(*args, **kwargs):
         process = await original_create_subprocess_exec(*args, **kwargs)
-        process_spy['process'] = process
+        process_spy["process"] = process
         return process
 
     with pytest.MonkeyPatch.context() as m:
@@ -64,8 +63,8 @@ except KeyboardInterrupt:
         # Give it time to start
         await asyncio.sleep(0.5)
 
-        assert 'process' in process_spy, "Subprocess should have started"
-        proc = process_spy['process']
+        assert "process" in process_spy, "Subprocess should have started"
+        proc = process_spy["process"]
         pid = proc.pid
 
         # Check if process is running (signal 0)
@@ -90,7 +89,10 @@ except KeyboardInterrupt:
         except OSError:
             is_running = False
 
-        assert not is_running, f"Subprocess {pid} should have been killed after task cancellation"
+        assert not is_running, (
+            f"Subprocess {pid} should have been killed after task cancellation"
+        )
+
 
 @pytest.mark.asyncio
 async def test_unbounded_output_limit():
@@ -118,4 +120,6 @@ print("A" * 1024 * 1024 * 10) # 10MB
     output_len = len(res["output"])
 
     # This assertion is expected to fail currently
-    assert output_len <= LIMIT + 1024, f"Output length {output_len} exceeds limit {LIMIT}"
+    assert output_len <= LIMIT + 1024, (
+        f"Output length {output_len} exceeds limit {LIMIT}"
+    )

--- a/test/test_session_removal.py
+++ b/test/test_session_removal.py
@@ -1,0 +1,108 @@
+import json
+
+from copium_loop.ui import Dashboard
+
+
+def test_session_removal_when_file_deleted(tmp_path):
+    # Initialize Dashboard
+    dash = Dashboard()
+
+    # Use tmp_path for log_dir
+    dash.log_dir = tmp_path
+
+    # 1. Create multiple .jsonl files
+    session1_file = tmp_path / "session1.jsonl"
+    session2_file = tmp_path / "session2.jsonl"
+
+    session1_file.write_text(
+        json.dumps(
+            {
+                "node": "coder",
+                "event_type": "status",
+                "data": "active",
+                "timestamp": "2024-01-01T00:00:00",
+            }
+        )
+        + "\n"
+    )
+    session2_file.write_text(
+        json.dumps(
+            {
+                "node": "coder",
+                "event_type": "status",
+                "data": "active",
+                "timestamp": "2024-01-01T00:00:00",
+            }
+        )
+        + "\n"
+    )
+
+    # 2. Update and assert sessions are created
+    dash.update_from_logs()
+    assert "session1" in dash.sessions
+    assert "session2" in dash.sessions
+    assert "session1" in dash.log_offsets
+    assert "session2" in dash.log_offsets
+
+    # 3. Delete one .jsonl file
+    session1_file.unlink()
+
+    # 4. Update again and assert session1 is removed
+    dash.update_from_logs()
+
+    assert "session1" not in dash.sessions, (
+        "session1 should have been removed from dash.sessions"
+    )
+    assert "session2" in dash.sessions
+    assert "session1" not in dash.log_offsets, (
+        "session1 should have been removed from dash.log_offsets"
+    )
+    assert "session2" in dash.log_offsets
+
+
+def test_pagination_clamping_after_removal(tmp_path):
+    dash = Dashboard()
+    dash.log_dir = tmp_path
+    dash.sessions_per_page = 1
+
+    # Create 2 sessions
+    (tmp_path / "s1.jsonl").write_text(
+        json.dumps(
+            {
+                "node": "coder",
+                "event_type": "status",
+                "data": "active",
+                "timestamp": "2024-01-01T00:00:00",
+            }
+        )
+        + "\n"
+    )
+    (tmp_path / "s2.jsonl").write_text(
+        json.dumps(
+            {
+                "node": "coder",
+                "event_type": "status",
+                "data": "active",
+                "timestamp": "2024-01-01T00:00:01",
+            }
+        )
+        + "\n"
+    )
+
+    dash.update_from_logs()
+    assert len(dash.sessions) == 2
+
+    # Go to page 1 (second page)
+    dash.current_page = 1
+
+    # Delete both sessions
+    (tmp_path / "s1.jsonl").unlink()
+    (tmp_path / "s2.jsonl").unlink()
+
+    dash.update_from_logs()
+
+    # We also need to call make_layout because that's where clamping happens currently
+    dash.make_layout()
+
+    assert len(dash.sessions) == 0
+    assert dash.current_page == 0


### PR DESCRIPTION
- Updated Dashboard.update_from_logs to identify and remove sessions no longer present in the filesystem.
- Cleaned up session data from Dashboard.sessions and Dashboard.log_offsets.
- Added test/test_session_removal.py to verify session removal and pagination clamping.
- Ran ruff to ensure code quality.

Closes https://github.com/gfxblit/copium-loop/issues/17