### PR TITLE
feat: enforce 80% test coverage in Tester node

### DIFF
--- a/src/copium_loop/constants.py
+++ b/src/copium_loop/constants.py
@@ -26,3 +26,6 @@ COMMAND_TIMEOUT = 1200
 
 # Max output size in bytes (1MB) to prevent memory exhaustion
 MAX_OUTPUT_SIZE = 1024 * 1024
+
+# Default minimum test coverage percentage
+DEFAULT_MIN_COVERAGE = 80

--- a/src/copium_loop/discovery.py
+++ b/src/copium_loop/discovery.py
@@ -1,5 +1,7 @@
 import os
 
+from copium_loop.constants import DEFAULT_MIN_COVERAGE
+
 
 def get_package_manager() -> str:
     """Detects the package manager based on lock files."""
@@ -27,8 +29,13 @@ def get_test_command() -> tuple[str, list[str]]:
         or os.path.exists("setup.py")
         or os.path.exists("requirements.txt")
     ):
+        min_cov = os.environ.get("COPIUM_MIN_COVERAGE", str(DEFAULT_MIN_COVERAGE))
         test_cmd = "pytest"
-        test_args = ["--cov=src", "--cov-report=term-missing"]
+        test_args = [
+            "--cov=src",
+            "--cov-report=term-missing",
+            f"--cov-fail-under={min_cov}",
+        ]
 
     return test_cmd, test_args
 

--- a/test/test_discovery.py
+++ b/test/test_discovery.py
@@ -12,7 +12,24 @@ def test_get_test_command_pytest():
     with patch("os.path.exists", side_effect=side_effect):
         cmd, args = discovery.get_test_command()
         assert cmd == "pytest"
-        assert args == ["--cov=src", "--cov-report=term-missing"]
+        assert "--cov=src" in args
+        assert "--cov-report=term-missing" in args
+        assert "--cov-fail-under=80" in args
+
+
+def test_get_test_command_pytest_custom_coverage():
+    """Test that get_test_command respects COPIUM_MIN_COVERAGE."""
+
+    def side_effect(path):
+        return path == "pyproject.toml"
+
+    with (
+        patch("os.path.exists", side_effect=side_effect),
+        patch.dict("os.environ", {"COPIUM_MIN_COVERAGE": "90"}),
+    ):
+        cmd, args = discovery.get_test_command()
+        assert cmd == "pytest"
+        assert "--cov-fail-under=90" in args
 
 
 def test_get_test_command_npm_priority():


### PR DESCRIPTION
- Added DEFAULT_MIN_COVERAGE to constants.py
- Updated discovery.py to include --cov-fail-under in pytest command
- Enhanced Tester node to detect coverage failures and return FAIL (Coverage)
- Added unit tests for coverage enforcement and discovery

Closes https://github.com/gfxblit/copium-loop/issues/26