### PR TITLE
fix: remove pane ID from session name generation

### DIFF
--- a/src/copium_loop/telemetry.py
+++ b/src/copium_loop/telemetry.py
@@ -233,7 +233,7 @@ def get_telemetry() -> Telemetry:
             import subprocess
 
             res = subprocess.run(
-                ["tmux", "display-message", "-p", "#S_#D"],
+                ["tmux", "display-message", "-p", "#S"],
                 capture_output=True,
                 text=True,
                 check=False,

--- a/test/test_telemetry.py
+++ b/test/test_telemetry.py
@@ -39,9 +39,16 @@ def test_get_telemetry_uses_tmux_session_name():
     mock_res.returncode = 0
     mock_res.stdout = "my-awesome-session\n"
 
-    with patch("subprocess.run", return_value=mock_res):
+    with patch("subprocess.run", return_value=mock_res) as mock_run:
         t = telemetry.get_telemetry()
         assert t.session_id == "my-awesome-session"
+        # Verify we requested ONLY the session name (#S), not pane ID (#D)
+        mock_run.assert_called_with(
+            ["tmux", "display-message", "-p", "#S"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
 
 
 def test_get_telemetry_fallback_to_timestamp():


### PR DESCRIPTION
This change updates the telemetry session ID generation to only use the tmux session name (#S) instead of appending the pane ID (#S_#D). This ensures that restarting the tool in a different pane or the same pane allows appending to the existing session log, preserving context.

Fixes #35

Closes https://github.com/gfxblit/copium-loop/issues/35