### PR TITLE
fix: remove [skip ci] from journaler commits

### DIFF
--- a/src/copium_loop/nodes/pr_creator.py
+++ b/src/copium_loop/nodes/pr_creator.py
@@ -53,7 +53,7 @@ async def pr_creator(state: AgentState) -> dict:
             telemetry.log_output("pr_creator", msg)
             print(msg, end="")
             await add(".")
-            await commit("docs: update GEMINI.md and session memory [skip ci]")
+            await commit("docs: update GEMINI.md and session memory")
 
         # 3. Push to origin
         msg = "Pushing to origin...\n"


### PR DESCRIPTION
This PR removes the `[skip ci]` tag from the commit message in the `pr_creator` node. 

The `[skip ci]` tag was causing PR previews and other CI checks to be skipped, which prevented proper validation of automated updates to `GEMINI.md` and session memory.

**Changes:**
- Removed `[skip ci]` from the commit message in `src/copium_loop/nodes/pr_creator.py`.