### PR TITLE
check start node issue56

### DIFF
--- a/src/copium_loop/__main__.py
+++ b/src/copium_loop/__main__.py
@@ -158,6 +158,10 @@ async def async_main():
             await workflow.notify("Workflow: Failed", msg, 5)
             sys.exit(1)
 
+    except ValueError as err:
+        print(f"Error: {err}", file=sys.stderr)
+        sys.exit(1)
+
     except Exception as err:
         print(f"Workflow failed: {err}", file=sys.stderr)
         await workflow.notify(

--- a/src/copium_loop/constants.py
+++ b/src/copium_loop/constants.py
@@ -12,6 +12,17 @@ REVIEWER_MODELS = [
     "gemini-2.5-flash",
 ]
 
+# Valid workflow nodes
+VALID_NODES = [
+    "coder",
+    "tester",
+    "architect",
+    "reviewer",
+    "pr_pre_checker",
+    "pr_creator",
+    "journaler",
+]
+
 # Architect node models
 ARCHITECT_MODELS = [
     "gemini-3-flash-preview",

--- a/src/copium_loop/copium_loop.py
+++ b/src/copium_loop/copium_loop.py
@@ -7,7 +7,7 @@ import traceback
 
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from copium_loop.constants import NODE_TIMEOUT
+from copium_loop.constants import NODE_TIMEOUT, VALID_NODES
 from copium_loop.discovery import get_test_command
 from copium_loop.git import get_head
 from copium_loop.graph import create_graph
@@ -34,18 +34,9 @@ class WorkflowManager:
 
     def create_graph(self):
         """Creates and compiles the workflow graph."""
-        valid_nodes = [
-            "coder",
-            "tester",
-            "architect",
-            "reviewer",
-            "pr_pre_checker",
-            "pr_creator",
-            "journaler",
-        ]
-        if self.start_node and self.start_node not in valid_nodes:
+        if self.start_node and self.start_node not in VALID_NODES:
             print(f'Warning: Invalid start node "{self.start_node}".')
-            print(f"Valid nodes are: {', '.join(valid_nodes)}")
+            print(f"Valid nodes are: {', '.join(VALID_NODES)}")
             print('Falling back to "coder".')
         self.graph = create_graph(self._wrap_node, self.start_node)
         return self.graph
@@ -123,6 +114,9 @@ class WorkflowManager:
 
     async def run(self, input_prompt: str, initial_state: dict | None = None):
         """Run the workflow with the given prompt."""
+        if self.start_node and self.start_node not in VALID_NODES:
+            raise ValueError(f"Invalid start node: {self.start_node}. Valid nodes are: {', '.join(VALID_NODES)}")
+
         if not await self.verify_environment():
             return {"error": "Environment verification failed."}
 

--- a/src/copium_loop/graph.py
+++ b/src/copium_loop/graph.py
@@ -1,5 +1,6 @@
 from langgraph.graph import END, START, StateGraph
 
+from copium_loop.constants import VALID_NODES
 from copium_loop.nodes import (
     architect,
     coder,
@@ -31,16 +32,7 @@ def create_graph(wrap_node_func, start_node: str | None = None):
     workflow.add_node("journaler", wrap_node_func("journaler", journaler))
 
     # Determine entry point
-    valid_nodes = [
-        "coder",
-        "tester",
-        "architect",
-        "reviewer",
-        "pr_pre_checker",
-        "pr_creator",
-        "journaler",
-    ]
-    entry_node = start_node if start_node in valid_nodes else "coder"
+    entry_node = start_node if start_node in VALID_NODES else "coder"
 
     # Edges
     workflow.add_edge(START, entry_node)

--- a/test/test_cli_validation.py
+++ b/test/test_cli_validation.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+
+
+def test_cli_invalid_start_node():
+    """
+    Test that the CLI fails with a non-zero exit code and prints an error message
+    when an invalid start node is provided.
+    """
+    # Run the CLI command
+    env = {"PYTHONPATH": "src"}
+    result = subprocess.run(
+        [sys.executable, "-m", "copium_loop", "-s", "invalid_node", "test prompt"],
+        capture_output=True,
+        text=True,
+        env=env
+    )
+
+    # Check exit code
+    assert result.returncode != 0, f"Expected non-zero exit code, got {result.returncode}"
+
+    # Check stderr for error message
+    # Note: The exact error message might change during implementation, but it should contain "invalid start node"
+    assert "Invalid start node" in result.stdout or "Invalid start node" in result.stderr
+    assert "Valid nodes are:" in result.stdout or "Valid nodes are:" in result.stderr


### PR DESCRIPTION
- **Fix(cli): Validate --start node early and exit informatively**
- **Fix lint and syntax errors in start node validation implementation**
- **Add warning when falling back to default start node in graph.py**
- **Add VALID_NODES to constants.py**
- **docs: update GEMINI.md and session memory**

Closes https://github.com/gfxblit/copium-loop/issues/56