### PR TITLE
refactor: pass prompt to gemini CLI using -p flag

### DIFF
--- a/src/copium_loop/gemini.py
+++ b/src/copium_loop/gemini.py
@@ -23,7 +23,7 @@ async def _execute_gemini(
     if model:
         cmd_args.extend(["-m", model])
 
-    cmd_args.append(prompt)
+    cmd_args.extend(["-p", prompt])
 
     # Prevent interactive prompts in sub-agents
     env = os.environ.copy()

--- a/test/test_gemini.py
+++ b/test/test_gemini.py
@@ -31,6 +31,9 @@ class TestExecuteGemini:
             assert "-m" in cmd_args
             m_index = cmd_args.index("-m")
             assert cmd_args[m_index + 1] == "test-model"
+            assert "-p" in cmd_args
+            p_index = cmd_args.index("-p")
+            assert cmd_args[p_index + 1] == "test prompt"
 
     @pytest.mark.asyncio
     async def test_execute_gemini_omits_model_flag_when_none(self):


### PR DESCRIPTION
Updates the gemini CLI invocation to use the -p flag for the prompt argument, ensuring robust argument parsing.