### PR TITLE
timeout not working issue63

### DIFF
--- a/src/copium_loop/gemini.py
+++ b/src/copium_loop/gemini.py
@@ -1,6 +1,6 @@
 import os
 
-from copium_loop.constants import COMMAND_TIMEOUT, DEFAULT_MODELS
+from copium_loop.constants import COMMAND_TIMEOUT, DEFAULT_MODELS, INACTIVITY_TIMEOUT
 from copium_loop.shell import stream_subprocess
 from copium_loop.telemetry import get_telemetry
 
@@ -11,10 +11,14 @@ async def _execute_gemini(
     args: list[str] | None = None,
     node: str | None = None,
     command_timeout: int | None = None,
+    inactivity_timeout: int | None = None,
 ) -> str:
     """Internal method to execute the Gemini CLI with a specific model."""
     if command_timeout is None:
         command_timeout = COMMAND_TIMEOUT
+
+    if inactivity_timeout is None:
+        inactivity_timeout = INACTIVITY_TIMEOUT
 
     if args is None:
         args = []
@@ -44,6 +48,7 @@ async def _execute_gemini(
         env,
         node,
         command_timeout,
+        inactivity_timeout=inactivity_timeout,
         capture_stderr=False,
     )
 
@@ -64,6 +69,7 @@ async def invoke_gemini(
     label: str | None = None,
     node: str | None = None,
     command_timeout: int | None = None,
+    inactivity_timeout: int | None = None,
 ) -> str:
     """
     Invokes the Gemini CLI with a prompt, supporting model fallback.
@@ -89,7 +95,12 @@ async def invoke_gemini(
             if verbose:
                 print(f"Using model: {model_display}")
             return await _execute_gemini(
-                prompt, model, args, node, command_timeout=command_timeout
+                prompt,
+                model,
+                args,
+                node,
+                command_timeout=command_timeout,
+                inactivity_timeout=inactivity_timeout,
             )
         except Exception as error:
             error_msg = str(error)

--- a/src/copium_loop/notifications.py
+++ b/src/copium_loop/notifications.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import os
 import subprocess
 
@@ -23,7 +24,8 @@ async def get_tmux_session() -> str:
                 return output
         except asyncio.TimeoutError:
             process.kill()
-            await process.wait()
+            with contextlib.suppress(asyncio.TimeoutError, Exception):
+                await asyncio.wait_for(process.communicate(), timeout=0.5)
     except Exception:
         pass
     return "no-tmux"


### PR DESCRIPTION
- **Fix timeout hang in shell utility by refactoring stream_subprocess to include monitor_task in wait set and handle orphaned grandchildren**
- **fix: resolve timeout hang and fix linting errors in shell tests**
- **docs: update GEMINI.md and session memory**

Closes https://github.com/gfxblit/copium-loop/issues/63