### PR TITLE
Remove redundant rebase conflict notification in pr_pre_checker node

### DIFF
--- a/src/copium_loop/nodes/pr_pre_checker.py
+++ b/src/copium_loop/nodes/pr_pre_checker.py
@@ -9,7 +9,6 @@ from copium_loop.git import (
     rebase,
     rebase_abort,
 )
-from copium_loop.notifications import notify
 from copium_loop.state import AgentState
 from copium_loop.telemetry import get_telemetry
 
@@ -72,11 +71,6 @@ async def pr_pre_checker(state: AgentState) -> dict:
             print(msg, end="")
             await rebase_abort(node="pr_pre_checker")
             error_msg = f"Automatic rebase on origin/main failed with the following error:\n{res_rebase['output']}\n\nThe rebase has been aborted to keep the repository in a clean state. Please manually resolve the conflicts by running 'git rebase origin/main', fixing the files, and committing the changes before trying again."
-            await notify(
-                "Workflow: Rebase Conflict",
-                "Automatic rebase failed. Manual resolution required by coder.",
-                4,
-            )
             telemetry.log_status("pr_pre_checker", "failed")
             return {
                 "review_status": "pr_failed",

--- a/test/nodes/test_pr_pre_checker.py
+++ b/test/nodes/test_pr_pre_checker.py
@@ -102,12 +102,10 @@ class TestPRPreChecker:
     @patch("copium_loop.nodes.pr_pre_checker.fetch", new_callable=AsyncMock)
     @patch("copium_loop.nodes.pr_pre_checker.rebase", new_callable=AsyncMock)
     @patch("copium_loop.nodes.pr_pre_checker.rebase_abort", new_callable=AsyncMock)
-    @patch("copium_loop.nodes.pr_pre_checker.notify", new_callable=AsyncMock)
     @patch("copium_loop.nodes.pr_pre_checker.os.path.exists")
     async def test_pr_pre_checker_rebase_fail(
         self,
         mock_exists,
-        mock_notify,
         mock_abort,
         mock_rebase,
         mock_fetch,
@@ -125,4 +123,3 @@ class TestPRPreChecker:
         assert result["review_status"] == "pr_failed"
         mock_fetch.assert_called_once_with(node="pr_pre_checker")
         mock_abort.assert_called_once_with(node="pr_pre_checker")
-        mock_notify.assert_called_once()


### PR DESCRIPTION
The notification was redundant as the conflict is already reported back to the coder node.
Updated unit tests to verify the removal of the notification call.

Closes #79

Closes https://github.com/gfxblit/copium-loop/issues/79