### PR TITLE
fix(ci): ensure temp git repo uses main branch in integration tests

### DIFF
--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -40,6 +40,9 @@ def temp_repo(tmp_path):
         ["git", "commit", "-m", "Initial commit"], check=True, capture_output=True
     )
 
+    # Rename branch to main to ensure consistency
+    subprocess.run(["git", "branch", "-M", "main"], check=True, capture_output=True)
+
     # Setup origin
     origin_dir = tmp_path / "origin"
     origin_dir.mkdir()


### PR DESCRIPTION
Fixes integration test failures in CI where the default git branch name differs from the expected `main` branch. By explicitly renaming the branch to `main` in the `temp_repo` fixture, the tests become robust against environment-specific git configurations.

---
*PR created automatically by Jules for task [16263861155502344265](https://jules.google.com/task/16263861155502344265) started by @gfxblit*