### PR TITLE
Fix flaky tests causing CI failures

### DIFF
--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -176,8 +176,8 @@ async def test_run_command_total_timeout_exceeded():
     """
     import time
 
-    # Use a sleep duration longer than the total_timeout
-    sleep_duration = 2
+    # Use a sleep duration significantly longer than the total_timeout to avoid CI flakes
+    sleep_duration = 10
     total_timeout = 0.5  # Shorter than sleep_duration
     start_time = time.monotonic()
     result = await shell.run_command(

--- a/test/test_telemetry.py
+++ b/test/test_telemetry.py
@@ -386,18 +386,23 @@ class TestFindLatestSession:
         monkeypatch.setattr(Path, "home", lambda: temp_log_dir.parent.parent)
 
         # Create multiple log files with different timestamps
+        import os
         import time
 
         session1 = temp_log_dir / "session1.jsonl"
         session1.write_text("{}\n")
-        time.sleep(0.01)
+        # Set mtime to 1000s
+        os.utime(session1, (1000, 1000))
 
         session2 = temp_log_dir / "session2.jsonl"
         session2.write_text("{}\n")
-        time.sleep(0.01)
+        # Set mtime to 2000s
+        os.utime(session2, (2000, 2000))
 
         session3 = temp_log_dir / "session3.jsonl"
         session3.write_text("{}\n")
+        # Set mtime to 3000s
+        os.utime(session3, (3000, 3000))
 
         session_id = find_latest_session()
         assert session_id == "session3"


### PR DESCRIPTION
This PR addresses CI test failures caused by flaky tests.
`test/test_telemetry.py`: Using `time.sleep(0.01)` was unreliable for creating files with distinct timestamps on systems with low filesystem resolution or high load. Switched to `os.utime` to explicitly set mtimes.
`test/test_shell.py`: The timeout test used a sleep duration (2s) that was too close to the timeout (0.5s) for slow CI environments where the test runner might be delayed. Increased sleep duration to 10s.

---
*PR created automatically by Jules for task [4876433362353956876](https://jules.google.com/task/4876433362353956876) started by @gfxblit*