### PR TITLE
fix: remove intermediate notifications from tester and pr_creator nodes

### DIFF
--- a/src/copium_loop/nodes/pr_creator.py
+++ b/src/copium_loop/nodes/pr_creator.py
@@ -3,7 +3,6 @@ import re
 
 from langchain_core.messages import SystemMessage
 
-from copium_loop import constants
 from copium_loop.git import (
     add,
     commit,
@@ -11,7 +10,6 @@ from copium_loop.git import (
     is_dirty,
     push,
 )
-from copium_loop.notifications import notify
 from copium_loop.shell import run_command
 from copium_loop.state import AgentState
 from copium_loop.telemetry import get_telemetry
@@ -132,12 +130,6 @@ async def pr_creator(state: AgentState) -> dict:
         msg = f"Error in PR creation: {error}\n"
         telemetry.log_output("pr_creator", msg)
         print(msg, end="")
-        message = (
-            "Max retries exceeded. Aborting."
-            if retry_count >= constants.MAX_RETRIES
-            else f"Failed to create PR: {error}"
-        )
-        await notify("Workflow: PR Failed", message, 5)
         telemetry.log_status("pr_creator", "failed")
         return {
             "review_status": "pr_failed",

--- a/src/copium_loop/nodes/tester.py
+++ b/src/copium_loop/nodes/tester.py
@@ -4,7 +4,6 @@ from langchain_core.messages import SystemMessage
 
 from copium_loop import constants
 from copium_loop.discovery import get_build_command, get_lint_command, get_test_command
-from copium_loop.notifications import notify
 from copium_loop.shell import run_command
 from copium_loop.state import AgentState
 from copium_loop.telemetry import get_telemetry
@@ -119,7 +118,6 @@ async def tester(state: AgentState) -> dict:
             )
 
         telemetry.log_output("tester", f"{message}\n")
-        await notify("Workflow: Tests Failed", message, 4)
         return {
             "test_output": f"{fail_prefix}\n" + output,
             "retry_count": retry_count + 1,

--- a/test/nodes/test_pr_creator.py
+++ b/test/nodes/test_pr_creator.py
@@ -146,12 +146,10 @@ class TestPrCreatorNode:
     @patch.object(pr_creator_module, "get_current_branch", new_callable=AsyncMock)
     @patch.object(pr_creator_module, "is_dirty", new_callable=AsyncMock)
     @patch.object(pr_creator_module, "push", new_callable=AsyncMock)
-    @patch.object(pr_creator_module, "notify", new_callable=AsyncMock)
     @patch.object(pr_creator_module, "os")
     async def test_pr_creator_push_failure(
         self,
         mock_os,
-        mock_notify,
         mock_push,
         mock_is_dirty,
         mock_branch,
@@ -165,4 +163,3 @@ class TestPrCreatorNode:
         result = await pr_creator({"retry_count": 0})
         assert result["review_status"] == "pr_failed"
         assert "Git push failed" in result["messages"][0].content
-        mock_notify.assert_called_once()

--- a/test/nodes/test_tester.py
+++ b/test/nodes/test_tester.py
@@ -94,7 +94,6 @@ class TestTesterNode:
             patch.object(
                 tester_module, "run_command", new_callable=AsyncMock
             ) as mock_run,
-            patch.object(tester_module, "notify", new_callable=AsyncMock),
             patch.object(
                 tester_module,
                 "get_build_command",
@@ -124,7 +123,6 @@ class TestTesterNode:
             patch.object(
                 tester_module, "run_command", new_callable=AsyncMock
             ) as mock_run,
-            patch.object(tester_module, "notify", new_callable=AsyncMock),
             patch.object(
                 tester_module,
                 "get_build_command",
@@ -156,7 +154,6 @@ class TestTesterNode:
             patch.object(
                 tester_module, "run_command", new_callable=AsyncMock
             ) as mock_run,
-            patch.object(tester_module, "notify", new_callable=AsyncMock),
             patch.object(
                 tester_module,
                 "get_build_command",
@@ -185,7 +182,6 @@ class TestTesterNode:
             patch.object(
                 tester_module, "run_command", new_callable=AsyncMock
             ) as mock_run,
-            patch.object(tester_module, "notify", new_callable=AsyncMock),
             patch.object(
                 tester_module,
                 "get_build_command",
@@ -217,7 +213,6 @@ class TestTesterNode:
             patch.object(
                 tester_module, "run_command", new_callable=AsyncMock
             ) as mock_run,
-            patch.object(tester_module, "notify", new_callable=AsyncMock),
             patch.object(
                 tester_module,
                 "get_build_command",
@@ -248,7 +243,6 @@ class TestTesterNode:
             patch.object(
                 tester_module, "run_command", new_callable=AsyncMock
             ) as mock_run,
-            patch.object(tester_module, "notify", new_callable=AsyncMock),
             patch.object(
                 tester_module,
                 "get_build_command",


### PR DESCRIPTION
- Removed notify calls and imports from tester and pr_creator nodes to reduce notification noise.
- Final workflow status notifications are still handled by __main__.py.
- Updated unit tests to remove notify mocks and assertions.

Closes #91

Closes https://github.com/gfxblit/copium-loop/issues/91