### PR TITLE
🎨 Palette: Add Header and Footer to Dashboard

### DIFF
--- a/src/copium_loop/ui/textual_dashboard.py
+++ b/src/copium_loop/ui/textual_dashboard.py
@@ -6,7 +6,7 @@ from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal
-from textual.widgets import Static
+from textual.widgets import Footer, Header, Static
 
 from ..codexbar import CodexbarClient
 from .footer_stats import CodexStatsStrategy, SystemStatsStrategy
@@ -71,8 +71,10 @@ class TextualDashboard(App):
         self.enable_polling = enable_polling
 
     def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
         yield Horizontal(id="sessions-container")
         yield Static(id="stats-bar")
+        yield Footer()
 
     def on_mount(self) -> None:
         if self.enable_polling:

--- a/test/ui/test_dashboard_structure.py
+++ b/test/ui/test_dashboard_structure.py
@@ -1,0 +1,14 @@
+import pytest
+from textual.widgets import Footer, Header
+
+from copium_loop.ui.textual_dashboard import TextualDashboard
+
+
+@pytest.mark.asyncio
+async def test_dashboard_structure(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    app = TextualDashboard(log_dir=log_dir, enable_polling=False)
+    async with app.run_test():
+        assert app.query_one(Header)
+        assert app.query_one(Footer)


### PR DESCRIPTION
Added standard Textual Header and Footer to the dashboard. The Header displays the application title and clock, while the Footer automatically lists available key bindings, improving discoverability and accessibility.

* Added `Header` and `Footer` to `src/copium_loop/ui/textual_dashboard.py` imports and `compose` method.
* Added `test/ui/test_dashboard_structure.py` to verify the presence of `Header` and `Footer` widgets.

---
*PR created automatically by Jules for task [4021847744741053190](https://jules.google.com/task/4021847744741053190) started by @gfxblit*