### PR TITLE
⚡ Bolt: Optimize shell output buffering and cleaning

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - Shell Output Buffering Optimization
+**Learning:** Found O(N^2) string concatenation and repeated regex compilation in `stream_subprocess` in `src/copium_loop/shell.py`. This can degrade performance significantly with large outputs.
+**Action:** Use list accumulation + `"".join()` and pre-compile regexes at module level for string processing tasks in high-throughput streams.


### PR DESCRIPTION
💡 **What**:
- Replaced string concatenation (`+=`) in `stream_subprocess` loop with list accumulation (`[].append()`) and final `"".join()`.
- Moved `re.compile` for ANSI and control character regexes to module scope (`ANSI_ESCAPE_RE`, `CONTROL_CHAR_RE`).
- Increased `stream.read()` buffer size from 1024 to 8192 bytes.
- Updated truncation logic to work with list-based buffering.

🎯 **Why**:
- String concatenation in a loop has O(N^2) complexity, which degrades performance significantly as output size grows (up to 1MB allowed).
- Recompiling regexes for every chunk (potentially thousands of times) is unnecessary CPU overhead.
- Small read buffers increase the number of context switches and I/O system calls.

📊 **Impact**:
- Reduces memory copying overhead by ~500x for 1MB output (theoretical).
- Reduces regex compilation overhead to near zero.
- Reduces I/O system calls by 8x.

🔬 **Measurement**:
- Verified with `test/test_shell.py` and full test suite (`pytest test/`).
- Functionality remains identical, but execution should be more CPU and memory efficient for large outputs.

---
*PR created automatically by Jules for task [2168669406713286898](https://jules.google.com/task/2168669406713286898) started by @gfxblit*