### PR TITLE
Remove journaler node from default UI (Issue #109)

### DIFF
--- a/src/copium_loop/ui/column.py
+++ b/src/copium_loop/ui/column.py
@@ -23,7 +23,6 @@ class SessionColumn:
             "architect": MatrixPillar("architect"),
             "reviewer": MatrixPillar("reviewer"),
             "pr_pre_checker": MatrixPillar("pr_pre_checker"),
-            "journaler": MatrixPillar("journaler"),
             "pr_creator": MatrixPillar("pr_creator"),
         }
 

--- a/test/ui/test_issue57_node_names.py
+++ b/test/ui/test_issue57_node_names.py
@@ -19,7 +19,6 @@ def test_actual_node_names_in_ui():
         "architect",
         "reviewer",
         "pr_pre_checker",
-        "journaler",
         "pr_creator",
     ]
 
@@ -35,8 +34,9 @@ def test_actual_node_names_in_ui():
             f"Node name {node.upper()} not found in UI output"
         )
 
-    # Specifically check that "JOURNAL" (the old name) is NOT there as a standalone header
-    assert "JOURNAL" not in output or "JOURNALER" in output
+    # Specifically check that "JOURNALER" is NOT there as a standalone header
+    assert "JOURNALER" not in output
+    assert "JOURNAL" not in output
 
 
 @pytest.mark.asyncio
@@ -70,6 +70,23 @@ async def test_dynamic_node_discovery_in_ui(tmp_path):
 
         # Check if the new node was added to pillars model
         assert "security_scanner" in widget.session_column.pillars
+
+        # Create an event for the journaler node (which is hidden by default)
+        journaler_event = {
+            "node": "journaler",
+            "event_type": "status",
+            "data": "active",
+            "timestamp": "2026-02-03T12:05:00",
+        }
+        with open(log_file, "a") as f:
+            f.write(json.dumps(journaler_event) + "\n")
+
+        # Update from logs again
+        await app.update_from_logs()
+        await pilot.pause()
+
+        # Check if journaler was added
+        assert "journaler" in widget.session_column.pillars
 
         # Wait for widget mount
         for _ in range(10):

--- a/test/ui/test_session_widget.py
+++ b/test/ui/test_session_widget.py
@@ -28,7 +28,7 @@ async def test_session_widget_contains_pillars():
         pillars = session_widget.query(PillarWidget)
         assert (
             len(pillars) >= 6
-        )  # coder, tester, architect, reviewer, pr_pre_checker, journaler
+        )  # coder, tester, architect, reviewer, pr_pre_checker, pr_creator
 
         coder_pillar = session_widget.query_one(
             "#pillar-test-session-coder", PillarWidget


### PR DESCRIPTION
- Remove 'journaler' from default pillars in SessionColumn.
- Update tests to reflect removal and verify dynamic addition still works.
- Fix outdated comment in SessionWidget test.

Closes https://github.com/gfxblit/copium-loop/issues/109