### PR TITLE
Fix git output parsing in CI by ignoring stderr

### DIFF
--- a/src/copium_loop/git.py
+++ b/src/copium_loop/git.py
@@ -3,13 +3,17 @@ from copium_loop.shell import run_command
 
 async def is_git_repo(node: str | None = None) -> bool:
     """Returns True if the current directory is inside a git repository."""
-    res = await run_command("git", ["rev-parse", "--is-inside-work-tree"], node=node)
+    res = await run_command(
+        "git", ["rev-parse", "--is-inside-work-tree"], node=node, capture_stderr=False
+    )
     return res["exit_code"] == 0
 
 
 async def get_current_branch(node: str | None = None) -> str:
     """Returns the current git branch name."""
-    res = await run_command("git", ["branch", "--show-current"], node=node)
+    res = await run_command(
+        "git", ["branch", "--show-current"], node=node, capture_stderr=False
+    )
     return res["output"].strip()
 
 
@@ -32,13 +36,17 @@ async def is_dirty(node: str | None = None) -> bool:
 
 async def get_head(node: str | None = None) -> str:
     """Returns the current HEAD commit hash."""
-    res = await run_command("git", ["rev-parse", "HEAD"], node=node)
+    res = await run_command(
+        "git", ["rev-parse", "HEAD"], node=node, capture_stderr=False
+    )
     return res["output"].strip()
 
 
 async def resolve_ref(ref: str, node: str | None = None) -> str | None:
     """Resolves a git ref to a commit hash. Returns None if ref doesn't exist."""
-    res = await run_command("git", ["rev-parse", "--verify", ref], node=node)
+    res = await run_command(
+        "git", ["rev-parse", "--verify", ref], node=node, capture_stderr=False
+    )
     if res["exit_code"] == 0:
         return res["output"].strip()
     return None

--- a/src/copium_loop/shell.py
+++ b/src/copium_loop/shell.py
@@ -261,6 +261,7 @@ async def run_command(
     args: list[str] | None = None,
     node: str | None = None,
     command_timeout: int | None = None,
+    capture_stderr: bool = True,
 ) -> dict:
     """
     Invokes a shell command and streams output to stdout.
@@ -300,7 +301,7 @@ async def run_command(
         node,
         command_timeout,
         inactivity_timeout=INACTIVITY_TIMEOUT,
-        capture_stderr=True,
+        capture_stderr=capture_stderr,
         on_timeout_callback=on_timeout,
     )
 

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -12,7 +12,9 @@ async def test_get_current_branch():
         mock_run.return_value = {"output": "main\n", "exit_code": 0}
         branch = await git.get_current_branch()
         assert branch == "main"
-        mock_run.assert_called_with("git", ["branch", "--show-current"], node=None)
+        mock_run.assert_called_with(
+            "git", ["branch", "--show-current"], node=None, capture_stderr=False
+        )
 
 
 @pytest.mark.asyncio
@@ -41,7 +43,9 @@ async def test_get_head():
         mock_run.return_value = {"output": "abc123\n", "exit_code": 0}
         head = await git.get_head()
         assert head == "abc123"
-        mock_run.assert_called_with("git", ["rev-parse", "HEAD"], node=None)
+        mock_run.assert_called_with(
+            "git", ["rev-parse", "HEAD"], node=None, capture_stderr=False
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes issue #122 where `test/test_issue92_diff_base.py` failed in CI but passed locally.
The failure was due to `run_command` capturing both stdout and stderr, and `git` commands in CI (or with certain configs) outputting to stderr, which was then mixed into the return value of functions like `resolve_ref`, causing incorrect commit hashes.
Modified `run_command` to optionally capture stderr, and disabled it for git query commands where clean output is essential.

---
*PR created automatically by Jules for task [10957092738214612027](https://jules.google.com/task/10957092738214612027) started by @gfxblit*