### PR TITLE
feat(cli): Add support for Jules LLM engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,9 @@ cython_debug/
 # Ruff stuff:
 .ruff_cache/
 
+# Jules output
+JULES_OUTPUT.txt
+
 # PyPI configuration file
 .pypirc
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ copium-loop --continue
 - `--monitor`, `-m`: Start the Matrix visualization monitor (Dashboard).
 - `--continue`, `-c`: Continue from the last incomplete workflow session.
 - `--session`: Specific session ID to monitor or continue.
+- `--engine`: The LLM engine to use (`gemini` or `jules`, default: `gemini`).
 - `--verbose`, `-v`: Enable verbose output (default: True).
 
 ## How It Works
 
-1. **Coder** → Implements using Gemini.
+1. **Coder** → Implements using the selected LLM engine (Gemini or Jules).
 2. **Test Runner** → Runs `npm test`, `pnpm test`, or `pytest`. Automatically detects the project type and package manager.
-3. **Reviewer** → Reviews commits/diffs using Gemini Pro.
+3. **Reviewer** → Reviews commits/diffs using the selected LLM engine.
 4. **PR Creator** → Pushes to a feature branch & creates a Pull Request via `gh` CLI. If a GitHub issue URL is found in the prompt, it automatically links the PR to that issue.
 
 Loops on failures (max 10 retries total).

--- a/src/copium_loop/engine/base.py
+++ b/src/copium_loop/engine/base.py
@@ -23,3 +23,8 @@ class LLMEngine(ABC):
     def sanitize_for_prompt(self, text: str, max_length: int = 12000) -> str:
         """Sanitizes text for inclusion in a prompt."""
         pass
+
+    @abstractmethod
+    async def verify(self) -> bool:
+        """Verifies that the engine is correctly configured and usable."""
+        pass

--- a/src/copium_loop/engine/factory.py
+++ b/src/copium_loop/engine/factory.py
@@ -1,0 +1,30 @@
+from copium_loop.engine.base import LLMEngine
+from copium_loop.engine.gemini import GeminiEngine
+from copium_loop.engine.jules import JulesEngine
+
+
+def engine_factory(engine_type: str | None = None) -> LLMEngine:
+    """
+    Factory function to create an LLM engine instance.
+
+    Args:
+        engine_type: The type of engine to create ("gemini" or "jules").
+                     Defaults to "gemini" if None or empty.
+
+    Returns:
+        An instance of LLMEngine.
+
+    Raises:
+        ValueError: If the engine_type is unknown.
+    """
+    if not engine_type:
+        return GeminiEngine()
+
+    engine_type = engine_type.lower()
+
+    if engine_type == "gemini":
+        return GeminiEngine()
+    elif engine_type == "jules":
+        return JulesEngine()
+    else:
+        raise ValueError(f"Unknown engine: {engine_type}")

--- a/src/copium_loop/engine/gemini.py
+++ b/src/copium_loop/engine/gemini.py
@@ -162,3 +162,13 @@ class GeminiEngine(LLMEngine):
             safe_text = safe_text[:max_length] + "\n... (truncated for brevity)"
 
         return safe_text
+
+    async def verify(self) -> bool:
+        """Verifies that the Gemini CLI is installed and working."""
+        try:
+            from copium_loop.shell import run_command
+
+            res = await run_command("gemini", ["--version"])
+            return res["exit_code"] == 0
+        except Exception:
+            return False

--- a/src/copium_loop/state.py
+++ b/src/copium_loop/state.py
@@ -1,14 +1,16 @@
-from typing import Annotated, Any, TypedDict
+from typing import Annotated, TypedDict
 
 from langchain_core.messages import BaseMessage
 from langgraph.graph.message import add_messages
+
+from copium_loop.engine.base import LLMEngine
 
 
 class AgentState(TypedDict):
     """The state of the workflow."""
 
     messages: Annotated[list[BaseMessage], add_messages]
-    engine: Any  # LLMEngine
+    engine: LLMEngine
     code_status: str
     test_output: str
     review_status: str

--- a/test/engine/test_base.py
+++ b/test/engine/test_base.py
@@ -15,5 +15,8 @@ def test_llm_engine_interface():
         def sanitize_for_prompt(self, text, _max_length=12000):
             return text
 
+        async def verify(self):
+            return True
+
     engine = MockEngine()
     assert engine is not None

--- a/test/engine/test_factory.py
+++ b/test/engine/test_factory.py
@@ -1,0 +1,26 @@
+import pytest
+
+from copium_loop.engine.factory import engine_factory
+from copium_loop.engine.gemini import GeminiEngine
+from copium_loop.engine.jules import JulesEngine
+
+
+def test_engine_factory_gemini():
+    engine = engine_factory("gemini")
+    assert isinstance(engine, GeminiEngine)
+
+
+def test_engine_factory_jules():
+    engine = engine_factory("jules")
+    assert isinstance(engine, JulesEngine)
+
+
+def test_engine_factory_default():
+    # Should default to gemini if None or empty
+    assert isinstance(engine_factory(None), GeminiEngine)
+    assert isinstance(engine_factory(""), GeminiEngine)
+
+
+def test_engine_factory_invalid():
+    with pytest.raises(ValueError, match="Unknown engine: unknown"):
+        engine_factory("unknown")

--- a/test/engine/test_jules.py
+++ b/test/engine/test_jules.py
@@ -345,7 +345,7 @@ async def test_jules_engine_invoke_sanitizes_prompt():
 
         # Check that the prompt passed to 'jules remote new' was sanitized
         args = mock_stream.call_args_list[0][0][1]
-        prompt_arg = args[args.index("-p") + 1]
+        prompt_arg = args[args.index("--session") + 1]
         assert "[user_request]" in prompt_arg
         assert "[/user_request]" in prompt_arg
         assert "<user_request>" not in prompt_arg

--- a/test/engine/test_jules_args.py
+++ b/test/engine/test_jules_args.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from copium_loop.engine.jules import JulesEngine
+
+
+@pytest.mark.asyncio
+async def test_jules_engine_invoke_with_models_keyword():
+    """
+    Test that JulesEngine.invoke accepts 'models' as a keyword argument,
+    matching the LLMEngine base class signature.
+    """
+    with (
+        patch("copium_loop.engine.jules.run_command") as mock_run,
+        patch("copium_loop.engine.jules.stream_subprocess") as mock_stream,
+        patch("builtins.open", MagicMock()) as mock_file_open,
+        patch("os.path.exists", return_value=True),
+        patch("asyncio.sleep", return_value=None),
+    ):
+        # Mock git remote detection
+        mock_run.side_effect = [
+            {"exit_code": 0, "output": "origin\n"},
+            {"exit_code": 0, "output": "https://github.com/owner/repo.git\n"},
+        ]
+
+        # Mock jules remote lifecycle
+        mock_stream.side_effect = [
+            ("Session ID: sess_123\n", 0, False, None),  # jules remote new
+            ("Status: Completed\n", 0, False, None),  # jules remote list
+            ("Pulled changes\n", 0, False, None),  # jules remote pull
+        ]
+
+        mock_file_open.return_value.__enter__.return_value.read.return_value = "Success"
+
+        engine = JulesEngine()
+        # This should NOT raise TypeError: JulesEngine.invoke() got an unexpected keyword argument 'models'
+        result = await engine.invoke(
+            "Test prompt", models=["gpt-4o", "claude-3-5-sonnet"], node="test_node"
+        )
+
+        assert result == "Success"

--- a/test/test_cli_validation.py
+++ b/test/test_cli_validation.py
@@ -22,8 +22,31 @@ def test_cli_invalid_start_node():
     )
 
     # Check stderr for error message
-    # Note: The exact error message might change during implementation, but it should contain "invalid start node"
     assert (
         "Invalid start node" in result.stdout or "Invalid start node" in result.stderr
     )
     assert "Valid nodes are:" in result.stdout or "Valid nodes are:" in result.stderr
+
+
+def test_cli_invalid_engine():
+    """
+    Test that the CLI fails with a non-zero exit code when an invalid engine is provided.
+    """
+    env = {"PYTHONPATH": "src"}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "copium_loop",
+            "--engine",
+            "invalid_engine",
+            "test prompt",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # argparse will handle invalid choices and exit with code 2
+    assert result.returncode != 0
+    assert "invalid choice: 'invalid_engine'" in result.stderr

--- a/test/test_workflow_engine_swap.py
+++ b/test/test_workflow_engine_swap.py
@@ -1,0 +1,94 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from copium_loop.copium_loop import WorkflowManager
+from copium_loop.engine.gemini import GeminiEngine
+from copium_loop.engine.jules import JulesEngine
+
+
+@pytest.mark.asyncio
+async def test_engine_hot_swap_on_continue():
+    """
+    Test that providing --engine on CLI overrides the engine in reconstructed state
+    when using --continue.
+    """
+    # 1. Setup mocks
+    with (
+        patch("copium_loop.copium_loop.get_telemetry"),
+        patch("copium_loop.copium_loop.is_git_repo", return_value=True),
+        patch("copium_loop.copium_loop.get_head", return_value="hash123"),
+        patch("copium_loop.copium_loop.get_test_command", return_value=("pytest", [])),
+        patch(
+            "copium_loop.copium_loop.run_command", new_callable=AsyncMock
+        ) as mock_run_cmd,
+        patch("copium_loop.copium_loop.create_graph") as mock_create_graph,
+    ):
+        mock_run_cmd.return_value = {"exit_code": 0, "output": "success"}
+
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke.return_value = {"status": "success"}
+        mock_create_graph.return_value = mock_graph
+
+        manager = WorkflowManager(start_node="coder")
+
+        # Initial state has GeminiEngine
+        reconstructed_state = {
+            "engine": GeminiEngine(),
+            "retry_count": 1,
+        }
+
+        # New engine from CLI is JulesEngine
+        new_engine = JulesEngine()
+
+        # We need to mock verify_environment as well or provide what it needs
+        with patch.object(manager, "verify_environment", return_value=True):
+            await manager.run(
+                "test prompt", initial_state=reconstructed_state, engine=new_engine
+            )
+
+            # Verify that ainvoke was called with the NEW engine
+            called_state = mock_graph.ainvoke.call_args[0][0]
+            assert isinstance(called_state["engine"], JulesEngine)
+            assert called_state["retry_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_engine_persists_on_continue_if_not_overridden():
+    """
+    Test that the engine from reconstructed state is used if no engine is provided on CLI.
+    """
+    # 1. Setup mocks
+    with (
+        patch("copium_loop.copium_loop.get_telemetry"),
+        patch("copium_loop.copium_loop.is_git_repo", return_value=True),
+        patch("copium_loop.copium_loop.get_head", return_value="hash123"),
+        patch("copium_loop.copium_loop.get_test_command", return_value=("pytest", [])),
+        patch(
+            "copium_loop.copium_loop.run_command", new_callable=AsyncMock
+        ) as mock_run_cmd,
+        patch("copium_loop.copium_loop.create_graph") as mock_create_graph,
+    ):
+        mock_run_cmd.return_value = {"exit_code": 0, "output": "success"}
+
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke.return_value = {"status": "success"}
+        mock_create_graph.return_value = mock_graph
+
+        manager = WorkflowManager(start_node="coder")
+
+        # Initial state has JulesEngine (maybe it was set in a previous run)
+        reconstructed_state = {
+            "engine": JulesEngine(),
+            "retry_count": 1,
+        }
+
+        with patch.object(manager, "verify_environment", return_value=True):
+            # No engine provided on CLI
+            await manager.run(
+                "test prompt", initial_state=reconstructed_state, engine=None
+            )
+
+            # Verify that ainvoke was called with the engine from state (JulesEngine)
+            called_state = mock_graph.ainvoke.call_args[0][0]
+            assert isinstance(called_state["engine"], JulesEngine)


### PR DESCRIPTION
This PR introduces support for the Jules LLM engine as an alternative to Gemini. It adds a new `--engine` CLI argument, implements the `JulesEngine` class, and refactors the workflow to handle dynamic engine selection. It also includes a fix for a UI regression in the dashboard where hotkeys were selecting sessions based on global index instead of page-relative index.

---
*PR created automatically by Jules for task [14744763986740952270](https://jules.google.com/task/14744763986740952270) started by @gfxblit*