### PR TITLE
🛡️ Sentinel: Fix case-insensitive prompt injection in GeminiEngine

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2026-02-16 - Case-Insensitive Prompt Injection
+**Vulnerability:** `sanitize_for_prompt` performed case-sensitive string replacement, allowing attackers to bypass sanitization using mixed-case tags (e.g., `</USER_REQUEST>` instead of `</user_request>`) to close XML blocks in the system prompt.
+**Learning:** Security sanitization logic must be robust against variations in input format (case, whitespace, encoding) that might be interpreted meaningfully by the consumer (LLM).
+**Prevention:** Use case-insensitive matching/replacement or normalize input before sanitization. Always assume the consumer (LLM) is "smart" enough to understand malformed or varied syntax.

--- a/test/test_gemini.py
+++ b/test/test_gemini.py
@@ -318,3 +318,15 @@ class TestSanitizeForPrompt:
         engine = GeminiEngine()
         assert engine.sanitize_for_prompt("") == ""
         assert engine.sanitize_for_prompt(None) == ""
+
+    def test_sanitize_escapes_tags_case_insensitive(self):
+        """Test sanitization escapes tags case-insensitively."""
+        engine = GeminiEngine()
+        text = "</TEST_OUTPUT> <User_Request> <git_diff>"
+        sanitized = engine.sanitize_for_prompt(text)
+        assert "</TEST_OUTPUT>" not in sanitized
+        assert "[/test_output]" in sanitized  # Standardized to lowercase
+        assert "<User_Request>" not in sanitized
+        assert "[user_request]" in sanitized
+        assert "<git_diff>" not in sanitized
+        assert "[git_diff]" in sanitized


### PR DESCRIPTION
**Vulnerability Fix:**
The `sanitize_for_prompt` method in `GeminiEngine` used case-sensitive string replacement to escape XML-like tags (e.g., `<user_request>`). This allowed attackers to bypass sanitization by using mixed-case tags (e.g., `</USER_REQUEST>`) to close blocks in the system prompt and inject instructions.

**Resolution:**
Updated `sanitize_for_prompt` to use regex with `re.IGNORECASE` to replace all variations of the tags with normalized, safe bracketed versions (e.g., `[user_request]`).

**Verification:**
Added a regression test `test_sanitize_escapes_tags_case_insensitive` in `test/test_gemini.py` which passes. Existing tests also pass.

**Sentinel Journal:**
Added a journal entry in `.jules/sentinel.md` documenting the learning about case-sensitivity in input sanitization.

---
*PR created automatically by Jules for task [1215498217674559681](https://jules.google.com/task/1215498217674559681) started by @gfxblit*