### PR TITLE
⚡ Bolt: Pre-compile regexes in shell.py

### DIFF
--- a/src/copium_loop/shell.py
+++ b/src/copium_loop/shell.py
@@ -13,6 +13,10 @@ from copium_loop.constants import (
 )
 from copium_loop.telemetry import get_telemetry
 
+# Pre-compile regexes for performance
+ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-9;]*[a-zA-Z]")
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]")
+
 
 class StreamLogger:
     """Helper to buffer output for line-based logging while streaming to stdout."""
@@ -136,10 +140,10 @@ def _clean_chunk(chunk: str | bytes) -> str:
         return str(chunk)
 
     # Remove ANSI escape codes
-    without_ansi = re.sub(r"\x1B\[[0-9;]*[a-zA-Z]", "", chunk)
+    without_ansi = ANSI_ESCAPE_RE.sub("", chunk)
 
     # Remove disruptive control characters (excluding TAB, LF, CR)
-    return re.sub(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]", "", without_ansi)
+    return CONTROL_CHAR_RE.sub("", without_ansi)
 
 
 async def stream_subprocess(


### PR DESCRIPTION
⚡ Bolt: Pre-compile regexes in shell.py

💡 What:
Moved regex patterns for ANSI escape codes and control characters to module-level compiled constants (`ANSI_ESCAPE_RE`, `CONTROL_CHAR_RE`) in `src/copium_loop/shell.py`. Updated `_clean_chunk` to use these compiled regexes.

🎯 Why:
The previous implementation used `re.sub()` with string patterns inside `_clean_chunk`, which is called for every chunk of subprocess output. This could lead to repeated regex compilation overhead (or cache lookups) in a hot path, especially during heavy output streaming.

📊 Impact:
Reduces overhead in the output processing loop. While Python caches regex compilations, using pre-compiled objects avoids the cache lookup and is a standard best practice for frequently used patterns.

🔬 Measurement:
Verified by running `test/test_shell.py` to ensure `run_command` behavior (including ANSI stripping) remains correct. Linting and formatting checks passed.

---
*PR created automatically by Jules for task [2715046852714233546](https://jules.google.com/task/2715046852714233546) started by @gfxblit*