### PR TITLE
fix(security): sanitize git_diff in architect and reviewer prompts

### DIFF
--- a/src/copium_loop/nodes/utils.py
+++ b/src/copium_loop/nodes/utils.py
@@ -34,7 +34,8 @@ async def get_architect_prompt(engine_type: str, state: dict) -> str:
     if initial_commit_hash and await is_git_repo(node="architect"):
         git_diff = await get_diff(initial_commit_hash, head=None, node="architect")
 
-    safe_git_diff = git_diff  # We assume engine handles sanitization if needed, or we can sanitize here
+    engine = state["engine"]
+    safe_git_diff = engine.sanitize_for_prompt(git_diff)
 
     return f"""You are a software architect. Your task is to evaluate the code changes for architectural integrity.
 
@@ -96,7 +97,8 @@ async def get_reviewer_prompt(engine_type: str, state: dict) -> str:
     if initial_commit_hash and await is_git_repo(node="reviewer"):
         git_diff = await get_diff(initial_commit_hash, head=None, node="reviewer")
 
-    safe_git_diff = git_diff
+    engine = state["engine"]
+    safe_git_diff = engine.sanitize_for_prompt(git_diff)
 
     return f"""You are a senior reviewer. Your task is to review the implementation provided by the current branch.
 

--- a/test/nodes/test_issue146_jules_refactor.py
+++ b/test/nodes/test_issue146_jules_refactor.py
@@ -12,8 +12,11 @@ from copium_loop.state import AgentState
 @pytest.mark.asyncio
 async def test_get_architect_prompt():
     """Verify architect prompt generation for different engines."""
+    mock_engine = MagicMock()
+    mock_engine.sanitize_for_prompt = MagicMock(side_effect=lambda x: x)
     state = AgentState(
         initial_commit_hash="sha123",
+        engine=mock_engine,
     )
 
     # Test Jules prompt
@@ -38,9 +41,12 @@ async def test_get_architect_prompt():
 @pytest.mark.asyncio
 async def test_get_reviewer_prompt():
     """Verify reviewer prompt generation for different engines."""
+    mock_engine = MagicMock()
+    mock_engine.sanitize_for_prompt = MagicMock(side_effect=lambda x: x)
     state = AgentState(
         initial_commit_hash="sha123",
         test_output="PASS",
+        engine=mock_engine,
     )
 
     # Test Jules prompt


### PR DESCRIPTION
Sanitize `git_diff` content using `engine.sanitize_for_prompt` in `get_architect_prompt` and `get_reviewer_prompt` to prevent prompt injection attacks.
Update unit tests to mock `engine.sanitize_for_prompt`.

---
*PR created automatically by Jules for task [3234656339381622708](https://jules.google.com/task/3234656339381622708) started by @gfxblit*