### PR TITLE
🎨 Palette: Add empty state to dashboard

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-18 - Textual Empty States
+**Learning:** Textual containers render as blank space when empty, which can be confused for a frozen application.
+**Action:** When a main container has no children, always mount a dedicated `Label` or widget with a clear "Empty State" message and call-to-action.

--- a/src/copium_loop/ui/textual_dashboard.py
+++ b/src/copium_loop/ui/textual_dashboard.py
@@ -6,7 +6,7 @@ from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal
-from textual.widgets import Static
+from textual.widgets import Label, Static
 
 from ..codexbar import CodexbarClient
 from .footer_stats import CodexStatsStrategy
@@ -33,6 +33,14 @@ class TextualDashboard(App):
 
     #stats-bar.hidden {
         display: none;
+    }
+
+    #empty-state-label {
+        width: 100%;
+        height: 100%;
+        content-align: center middle;
+        text-align: center;
+        color: $text-muted;
     }
     """
 
@@ -149,7 +157,21 @@ class TextualDashboard(App):
             current_widgets = list(container.query(SessionWidget))
             current_sids = [w.session_id for w in current_widgets]
 
-            if current_sids == visible_sids:
+            if not visible_sessions:
+                if not container.query("#empty-state-label"):
+                    await container.remove_children()
+                    await container.mount(
+                        Label(
+                            "No active sessions found.\nWaiting for workflow to start...",
+                            id="empty-state-label",
+                        )
+                    )
+                return
+
+            # If we have sessions, ensure empty state is gone
+            has_empty_label = bool(container.query("#empty-state-label"))
+
+            if current_sids == visible_sids and not has_empty_label:
                 # Just refresh existing
                 for widget in current_widgets:
                     await widget.refresh_ui()

--- a/test/ui/test_empty_state.py
+++ b/test/ui/test_empty_state.py
@@ -1,0 +1,25 @@
+import pytest
+from textual.widgets import Label
+
+from copium_loop.ui.textual_dashboard import TextualDashboard
+
+
+@pytest.mark.asyncio
+async def test_textual_dashboard_empty_state(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    app = TextualDashboard(log_dir=log_dir, enable_polling=False)
+    async with app.run_test() as pilot:
+        # Trigger update with empty logs
+        await app.update_from_logs()
+        await pilot.pause()
+
+        # Check for the empty state label
+        try:
+            # Checking presence is enough as the content is hardcoded in the source
+            app.query_one("#empty-state-label", Label)
+        except Exception:
+            pytest.fail(
+                "Empty state label '#empty-state-label' not found when no sessions are present."
+            )


### PR DESCRIPTION
Added a "No active sessions found" label to the Textual dashboard when no logs are present. This prevents the dashboard from looking broken or frozen when starting up or when the log directory is empty. Added `test/ui/test_empty_state.py` to verify behavior.

---
*PR created automatically by Jules for task [14602518479040564037](https://jules.google.com/task/14602518479040564037) started by @gfxblit*