### PR TITLE
🎨 Palette: Add session index to widget header

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-02-18 - Textual Empty States
 **Learning:** Textual containers render as blank space when empty, which can be confused for a frozen application.
 **Action:** When a main container has no children, always mount a dedicated `Label` or widget with a clear "Empty State" message and call-to-action.
+
+## 2026-10-24 - Textual Static Widget Testing
+**Learning:** `Static` widgets do not expose a `.renderable` attribute as a simple string during tests.
+**Action:** To verify the text content of a `Static` widget in tests, inspect `str(widget.render())` instead of `.renderable`.

--- a/src/copium_loop/ui/textual_dashboard.py
+++ b/src/copium_loop/ui/textual_dashboard.py
@@ -178,8 +178,10 @@ class TextualDashboard(App):
             else:
                 # Rebuild
                 await container.remove_children()
-                for session in visible_sessions:
-                    w = SessionWidget(session, id=f"session-{session.session_id}")
+                for i, session in enumerate(visible_sessions):
+                    w = SessionWidget(
+                        session, index=i + 1, id=f"session-{session.session_id}"
+                    )
                     await container.mount(w)
                     await w.refresh_ui()
 

--- a/src/copium_loop/ui/widgets/session.py
+++ b/src/copium_loop/ui/widgets/session.py
@@ -40,11 +40,14 @@ class SessionWidget(Vertical):
     }
     """
 
-    def __init__(self, session_column: SessionColumn, **kwargs):
+    def __init__(
+        self, session_column: SessionColumn, index: int | None = None, **kwargs
+    ):
         super().__init__(**kwargs)
         self.can_focus = True
         self.session_column = session_column
         self.session_id = session_column.session_id
+        self.index = index
         # We don't pre-populate self.pillars here because they need to be mounted in compose or refresh_ui
         self.pillars: dict[str, PillarWidget] = {}
 
@@ -87,7 +90,8 @@ class SessionWidget(Vertical):
                 header.styles.border = ("round", "yellow")
                 header.styles.color = "yellow"
 
-            header.update(f"{self.session_id}{status_suffix}")
+            prefix = f"[{self.index}] " if self.index is not None else ""
+            header.update(f"{prefix}{self.session_id}{status_suffix}")
             header.border_subtitle = ""
 
             container = self.query_one(

--- a/test/engine/test_issue169_jules_prompt_hashing.py
+++ b/test/engine/test_issue169_jules_prompt_hashing.py
@@ -20,8 +20,8 @@ def mock_session_manager():
 
     mock_sm.get_engine_state.side_effect = get_engine_state
     mock_sm.update_engine_state.side_effect = update_engine_state
-    mock_sm.update_jules_session.side_effect = (
-        lambda node, session_id, prompt_hash: update_engine_state(
+    mock_sm.update_jules_session.side_effect = lambda node, session_id, prompt_hash: (
+        update_engine_state(
             "jules", node, {"session_id": session_id, "prompt_hash": prompt_hash}
         )
     )

--- a/test/ui/test_session_widget_index.py
+++ b/test/ui/test_session_widget_index.py
@@ -1,0 +1,46 @@
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from copium_loop.ui.column import SessionColumn
+from copium_loop.ui.widgets.session import SessionWidget
+
+
+class MockApp(App):
+    def compose(self) -> ComposeResult:
+        # Create a session widget with an index
+        column = SessionColumn("session-with-index")
+        widget = SessionWidget(column, index=1, id="widget-1")
+        yield widget
+
+        # Create a session widget without an index
+        column2 = SessionColumn("session-without-index")
+        widget2 = SessionWidget(column2, id="widget-2")
+        yield widget2
+
+
+@pytest.mark.asyncio
+async def test_session_widget_index_display():
+    app = MockApp()
+    async with app.run_test() as pilot:
+        widget1 = app.query_one("#widget-1", SessionWidget)
+        widget2 = app.query_one("#widget-2", SessionWidget)
+
+        # Trigger refresh
+        await widget1.refresh_ui()
+        await widget2.refresh_ui()
+        await pilot.pause()
+
+        # Check header content for widget 1
+        header1 = widget1.query_one(f"#header-{widget1.session_id}", Static)
+        # Should contain "[1]"
+        assert "[1]" in str(header1.render())
+        assert "session-with-index" in str(header1.render())
+
+        # Check header content for widget 2
+        header2 = widget2.query_one(f"#header-{widget2.session_id}", Static)
+        # Should NOT contain "[2]" or "[]"
+        renderable_str = str(header2.render())
+        assert "[" not in renderable_str
+        assert "]" not in renderable_str
+        assert "session-without-index" in renderable_str


### PR DESCRIPTION
This change adds a session index (e.g., `[1]`, `[2]`) to the session widget header in the Textual dashboard. This provides a clear visual cue for the user to know which number key (1-9) to press to switch to the corresponding tmux session, improving accessibility and usability.

---
*PR created automatically by Jules for task [11281795777124215578](https://jules.google.com/task/11281795777124215578) started by @gfxblit*