### PR TITLE
⚡ Bolt: Optimize log file polling with heapq

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-02-18 - File Polling with Scandir and Metadata Caching
 **Learning:** Repeatedly globbing (`Path.glob`) and opening files in a tight loop (e.g., UI polling) is extremely CPU-intensive and I/O-bound. `os.scandir` + `mtime/size` caching avoids unnecessary `open()` calls, yielding ~5x performance improvement.
 **Action:** Use `os.scandir` for directory iteration and cache file metadata (`mtime`, `size`) to skip unchanged files in polling loops.
+
+## 2025-02-18 - Optimized Sorting for File Polling
+**Learning:** Sorting thousands of file entries by `mtime` (O(N log N)) every second for UI updates is a bottleneck, even with `os.scandir`. `heapq.nlargest` (O(N log K)) significantly reduces latency (from ~174ms to ~69ms for 10k files) when only the top K results are needed.
+**Action:** Use `heapq.nlargest` instead of `sort()` when filtering for the most recent files in a large directory.


### PR DESCRIPTION
Optimize `SessionManager.update_from_logs` to use `heapq.nlargest` for selecting the most recent log files. This avoids sorting the entire directory (O(N log N)) and instead creates a heap of size K (O(N log K)), where K is the number of sessions to display (default 100). This provides a measurable performance improvement for directories with thousands of log files.

- **What:** Replaced `list.sort` with `heapq.nlargest` in `SessionManager.update_from_logs`.
- **Why:** To reduce CPU usage and latency during frequent UI polling of large log directories.
- **Impact:** Benchmark showed reduction from ~174ms to ~69ms for 10k files (>2.5x speedup).
- **Measurement:** Added `test/ui/test_manager.py::test_manager_optimization` to verify correctness. Benchmarked with `benchmark_sort.py` (not included in commit).

---
*PR created automatically by Jules for task [14057721688633519746](https://jules.google.com/task/14057721688633519746) started by @gfxblit*