### PR TITLE
revert: downgrade Gemini models from 3.1 to 3

### DIFF
--- a/src/copium_loop/constants.py
+++ b/src/copium_loop/constants.py
@@ -1,9 +1,9 @@
-# Default models to try in order. Gemini-3.1 and 2.5
+# Default models to try in order. Gemini-3 and 2.5
 # share the same quota, so no point in add those as
 # fallbacks.
 MODELS = [
-    "gemini-3.1-pro-preview",
-    "gemini-3.1-flash-preview",
+    "gemini-3-pro-preview",
+    "gemini-3-flash-preview",
 ]
 
 # Valid workflow nodes

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -27,8 +27,8 @@ def test_agent_state_has_architect_status():
 
 
 def test_models_defined():
-    assert "gemini-3.1-pro-preview" in MODELS
-    assert "gemini-3.1-flash-preview" in MODELS
+    assert "gemini-3-pro-preview" in MODELS
+    assert "gemini-3-flash-preview" in MODELS
 
 
 def test_timeouts_defined():


### PR DESCRIPTION
This reverts the upgrade to Gemini 3.1 models, returning to Gemini 3 variants due to reported stability issues (Issue #212).
