### PR TITLE
🎨 Palette: Add session index to widget header

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Keyboard Shortcut Discovery
+**Learning:** Users often forget numeric shortcuts in TUI apps, especially when they map to dynamic lists.
+**Action:** Explicitly displaying the shortcut key (e.g. `[1]`) in the widget header dramatically improves discoverability without cluttering the UI. This is a reusable pattern for any indexed list in the TUI.

--- a/src/copium_loop/ui/textual_dashboard.py
+++ b/src/copium_loop/ui/textual_dashboard.py
@@ -182,16 +182,17 @@ class TextualDashboard(App):
 
             if current_sids == visible_sids and not has_empty_label:
                 # Just refresh existing
-                for widget in current_widgets:
+                for i, widget in enumerate(current_widgets, 1):
+                    widget.index = i
                     await widget.refresh_ui()
             else:
                 # Rebuild
                 await container.remove_children()
                 import re
 
-                for session in visible_sessions:
+                for i, session in enumerate(visible_sessions, 1):
                     safe_sid = re.sub(r"[^a-zA-Z0-9_\-]", "_", session.session_id)
-                    w = SessionWidget(session, id=f"session-{safe_sid}")
+                    w = SessionWidget(session, index=i, id=f"session-{safe_sid}")
                     await container.mount(w)
                     await w.refresh_ui()
 

--- a/src/copium_loop/ui/widgets/session.py
+++ b/src/copium_loop/ui/widgets/session.py
@@ -40,11 +40,12 @@ class SessionWidget(Vertical):
     }
     """
 
-    def __init__(self, session_column: SessionColumn, **kwargs):
+    def __init__(self, session_column: SessionColumn, index: int = 0, **kwargs):
         super().__init__(**kwargs)
         self.can_focus = True
         self.session_column = session_column
         self.session_id = session_column.session_id
+        self.index = index
         # We don't pre-populate self.pillars here because they need to be mounted in compose or refresh_ui
         self.pillars: dict[str, PillarWidget] = {}
 
@@ -95,7 +96,8 @@ class SessionWidget(Vertical):
                 header.styles.color = "yellow"
 
             display_name = self.session_column.display_name
-            header.update(f"{display_name}{status_suffix}")
+            prefix = f"[{self.index}] " if self.index > 0 else ""
+            header.update(f"{prefix}{display_name}{status_suffix}")
             header.border_subtitle = ""
 
             container = self.query_one(f"#pillars-container-{self.safe_id}", Vertical)

--- a/test/ui/test_session_widget.py
+++ b/test/ui/test_session_widget.py
@@ -10,13 +10,14 @@ from copium_loop.ui.widgets.session import SessionWidget
 
 
 class SessionWidgetMockApp(App):
-    def __init__(self, column=None):
+    def __init__(self, column=None, index=0):
         super().__init__()
         self.session_column = column or SessionColumn("test-session")
         self.session_widget = None
+        self.index = index
 
     def compose(self) -> ComposeResult:
-        self.session_widget = SessionWidget(self.session_column)
+        self.session_widget = SessionWidget(self.session_column, index=self.index)
         yield self.session_widget
 
 
@@ -169,3 +170,35 @@ async def test_session_widget_handles_no_prefix():
         rendered = str(header.render())
 
         assert "simple-branch" in rendered
+
+
+@pytest.mark.asyncio
+async def test_session_widget_displays_index():
+    col = SessionColumn("test-session")
+    # Pass index=1
+    app = SessionWidgetMockApp(col, index=1)
+    async with app.run_test():
+        widget = app.session_widget
+
+        await widget.refresh_ui()
+        header = widget.query_one(f"#header-{widget.safe_id}", Static)
+        rendered = str(header.render())
+
+        # We expect "[1]" to be in the header
+        assert "[1]" in rendered
+
+
+@pytest.mark.asyncio
+async def test_session_widget_no_index_for_zero():
+    col = SessionColumn("test-session")
+    # Pass index=0
+    app = SessionWidgetMockApp(col, index=0)
+    async with app.run_test():
+        widget = app.session_widget
+
+        await widget.refresh_ui()
+        header = widget.query_one(f"#header-{widget.safe_id}", Static)
+        rendered = str(header.render())
+
+        # We expect no "[0]" in the header
+        assert "[0]" not in rendered


### PR DESCRIPTION
💡 **What**: Added visual index indicators (e.g., `[1]`) to session widget headers in the dashboard.
🎯 **Why**: To make the `1-9` keyboard shortcuts for switching tmux sessions more discoverable and intuitive.
📸 **Before/After**:
    *   Before: `owner/repo/branch`
    *   After: `[1] owner/repo/branch`
♿ **Accessibility**: Improves keyboard navigation by explicitly mapping visual elements to their shortcuts.

---
*PR created automatically by Jules for task [12770960175076375457](https://jules.google.com/task/12770960175076375457) started by @gfxblit*