### PR TITLE
fix(ui): implement lean node UI content suppression and fixed weighting (issue #228)

### DIFF
--- a/src/copium_loop/ui/pillar.py
+++ b/src/copium_loop/ui/pillar.py
@@ -164,6 +164,9 @@ class MatrixPillar:
 
     def get_content_renderable(self, show_system: bool = False):
         """Returns the content renderable for the pillar, optionally filtering system logs."""
+        if self.is_lean_node():
+            return TailRenderable([], self.status)
+
         filtered_buffer = []
         for entry in self.buffer:
             if isinstance(entry, dict):

--- a/src/copium_loop/ui/widgets/session.py
+++ b/src/copium_loop/ui/widgets/session.py
@@ -117,23 +117,25 @@ class SessionWidget(Vertical):
                 # Active nodes should be very prominent.
                 # Nodes with history get some space but less than active.
                 # Idle nodes without history get minimal space.
-                # Lean nodes (tester, pr_pre_checker, pr_creator) are always smaller.
+                # Lean nodes (tester, pr_pre_checker, pr_creator) are always smaller and fixed.
                 is_lean = pillar_data.is_lean_node()
 
-                if pillar_data.status == "active":
+                if is_lean:
+                    weight = 1
+                    widget.styles.min_height = 3
+                elif pillar_data.status == "active":
                     count = len(pillar_data.buffer)
-                    # Lean active nodes get less weight than others
-                    base_weight = 50 if is_lean else 100
-                    weight = base_weight + (count * 2)
+                    # Non-lean active nodes get much more weight
+                    weight = 100 + (count * 2)
                     widget.styles.min_height = 4
                 elif len(pillar_data.buffer) > 0:
                     count = len(pillar_data.buffer)
-                    # Lean nodes with history get much less weight
-                    weight = (5 + count) if is_lean else (10 + count)
-                    widget.styles.min_height = 4 if not is_lean else 3
+                    # Non-lean nodes with history get some weight
+                    weight = 10 + count
+                    widget.styles.min_height = 4
                 else:
                     weight = 1
-                    widget.styles.min_height = 3 if not is_lean else 2
+                    widget.styles.min_height = 3
 
                 widget.styles.height = f"{weight}fr"
         except Exception:

--- a/test/ui/test_pillar.py
+++ b/test/ui/test_pillar.py
@@ -100,12 +100,12 @@ def test_matrix_pillar_filtering():
     # LLM output 1, LLM output 2, and the header
     assert any("--- CODER Node ---" in line for line in renderable_header.buffer)
 
-    # Lean node should return TailRenderable instead of Text object
+    # Lean node should return an empty TailRenderable
     pillar_lean = MatrixPillar("tester")
     pillar_lean.add_line("tester log")
     renderable_lean = pillar_lean.get_content_renderable()
     assert isinstance(renderable_lean, TailRenderable)
-    assert "tester log" in renderable_lean.buffer[0]
+    assert len(renderable_lean.buffer) == 0
 
 
 def test_matrix_pillar_time_suffix():

--- a/test/ui/test_pillar_widget.py
+++ b/test/ui/test_pillar_widget.py
@@ -39,20 +39,20 @@ def test_pillar_widget_updates_from_pillar():
 
 
 @pytest.mark.asyncio
-async def test_pillar_widget_lean_node_no_suppression():
-    """Verify that PillarWidget does NOT suppress content even for lean nodes."""
+async def test_pillar_widget_lean_node_content_suppression():
+    """Verify that PillarWidget DOES suppress content for lean nodes."""
     # Test with a lean node
     pillar = MatrixPillar("tester")
     app = MockApp()
     async with app.run_test():
         widget = PillarWidget(node_id="tester")
         await app.mount(widget)
-        pillar.add_line("This content should be visible")
+        pillar.add_line("This content should be suppressed")
 
-        # In the current implementation, MatrixPillar itself handles the suppression
+        # In the new implementation, MatrixPillar itself handles the suppression
         # when get_content_renderable is called.
         widget.update_from_pillar(pillar)
 
-        # For lean nodes, get_content_renderable now returns a TailRenderable
+        # For lean nodes, get_content_renderable now returns an empty TailRenderable
         renderable = pillar.get_content_renderable()
-        assert "This content should be visible" in renderable.buffer[0]
+        assert len(renderable.buffer) == 0

--- a/test/ui/test_session_widget.py
+++ b/test/ui/test_session_widget.py
@@ -131,9 +131,9 @@ async def test_lean_nodes_weight_and_content():
         # 100 base + 2 per line * 1 line = 102
         assert coder_widget.styles.height.value == 102
 
-        # Tester is lean and active, so it should have lower weight than coder
-        # 50 base + 2 per line * 1 line = 52
-        assert tester_widget.styles.height.value == 52
+        # Tester is lean and active, so it should have fixed weight 1 and min_height 3
+        assert tester_widget.styles.height.value == 1
+        assert tester_widget.styles.min_height.value == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Update MatrixPillar.get_content_renderable to suppress content for lean nodes.
- Update SessionWidget.refresh_ui to enforce fixed weight (1) and min_height (3) for lean nodes.
- Update tests to verify content suppression and weighting logic.

Closes https://github.com/gfxblit/copium-loop/issues/228