### PR TITLE
🛡️ Sentinel: Fix path traversal in git repo name extraction

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-03 - Path Traversal in Git Remote Parsing
+**Vulnerability:** The `get_repo_name` function extracted repository names from git remote URLs using a regex that allowed `..` sequences. This could allow a malicious remote URL to trick the application into using a path traversal string (e.g., `../evil`) as a repository identifier, potentially leading to unauthorized file access or manipulation if used in file paths.
+**Learning:** Regex-based parsing of untrusted input (like remote URLs) is often insufficient for security validation. Relying on character classes like `[\w\-\.]+` without explicitly forbidding dangerous sequences like `..` can leave gaps.
+**Prevention:** Always validate extracted identifiers against a strict allowlist (e.g., only alphanumeric and specific safe characters) or explicitly deny known dangerous patterns (blocklist) like `..` and leading slashes before using them in file system operations.

--- a/src/copium_loop/git.py
+++ b/src/copium_loop/git.py
@@ -158,6 +158,14 @@ async def get_repo_name(node: str | None = None) -> str:
     # The negative lookbehind (?<!/) ensures we don't match the protocol separator //
     match = re.search(r"(?<!/)[:/]([\w\-\.]+/[\w\-\.]+?)(?:\.git)?/?$", url)
     if match:
-        return match.group(1)
+        repo_name = match.group(1)
+
+        # Security check: Prevent path traversal in repo names
+        if ".." in repo_name or repo_name.startswith("/"):
+            raise ValueError(
+                f"Potentially malicious repo name detected (path traversal risk): {repo_name}"
+            )
+
+        return repo_name
 
     raise ValueError(f"Could not parse repo name from remote URL: {url}")

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -195,6 +195,26 @@ async def test_get_repo_name_parsing():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/../evil",
+        "https://github.com/owner/../evil",
+    ],
+)
+async def test_get_repo_name_security(url):
+    """Test that get_repo_name rejects potentially malicious repo names."""
+    with patch("copium_loop.git.run_command", new_callable=AsyncMock) as mock_run:
+        output = f"origin\t{url} (fetch)\n"
+        mock_run.return_value = {"exit_code": 0, "output": output}
+
+        with pytest.raises(
+            ValueError, match="Potentially malicious repo name detected"
+        ):
+            await get_repo_name()
+
+
+@pytest.mark.asyncio
 async def test_get_repo_name_no_remote():
     with patch("copium_loop.git.run_command", new_callable=AsyncMock) as mock_run:
         mock_run.return_value = {"exit_code": 0, "output": ""}


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix path traversal in git repo name extraction

🚨 Severity: HIGH
💡 Vulnerability: The `get_repo_name` function extracted repository names from git remote URLs using a regex that allowed `..` sequences. This could allow a malicious remote URL to trick the application into using a path traversal string (e.g., `../evil`) as a repository identifier.
🎯 Impact: If this `repo_name` is subsequently used in file system operations, it could allow writing or reading outside the intended directory.
🔧 Fix: Added explicit validation to reject repository names containing `..` or starting with `/`.
✅ Verification: Added `test_get_repo_name_security` to `test/test_git.py` which verifies that malicious URLs raise `ValueError`. Ran `pytest test/test_git.py` and confirmed it passes.

---
*PR created automatically by Jules for task [17238261826456463219](https://jules.google.com/task/17238261826456463219) started by @gfxblit*