### PR TITLE
architect injection for coder prompt issue249

### DIFF
--- a/src/copium_loop/engine/gemini.py
+++ b/src/copium_loop/engine/gemini.py
@@ -52,7 +52,14 @@ class GeminiEngine(LLMEngine):
             }
         )
 
-        stdout, stderr, exit_code, timed_out, timeout_message = await stream_subprocess(
+        (
+            stdout,
+            stderr,
+            interleaved,
+            exit_code,
+            timed_out,
+            timeout_message,
+        ) = await stream_subprocess(
             "gemini",
             cmd_args,
             env,

--- a/src/copium_loop/shell.py
+++ b/src/copium_loop/shell.py
@@ -28,6 +28,37 @@ ANSI_ESCAPE_RE = re.compile(
 CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]")
 
 
+class StreamBuffer:
+    """Handles accumulation and truncation of stream output."""
+
+    def __init__(self, max_size: int, label: str):
+        self.max_size = max_size
+        self.label = label
+        self.chunks = []
+        self.current_size = 0
+        self.truncated = False
+
+    def append(self, chunk: str):
+        """Appends a chunk, truncating if max_size is exceeded."""
+        if self.truncated or not chunk:
+            return
+
+        self.chunks.append(chunk)
+        self.current_size += len(chunk)
+
+        if self.current_size > self.max_size:
+            full_text = "".join(self.chunks)
+            self.chunks = [
+                full_text[: self.max_size],
+                f"\n[... {self.label} Truncated ...]\n",
+            ]
+            self.truncated = True
+
+    def get_content(self) -> str:
+        """Returns the accumulated (and possibly truncated) content."""
+        return "".join(self.chunks)
+
+
 class StreamLogger:
     """Helper to buffer output for line-based logging while streaming to stdout."""
 
@@ -169,10 +200,10 @@ async def stream_subprocess(
     capture_stderr: bool = True,
     on_timeout_callback=None,
     source: str = "system",
-) -> tuple[str, str, int, bool, str]:
+) -> tuple[str, str, str, int, bool, str]:
     """
     Common helper to execute a subprocess and stream its output.
-    Returns (stdout, stderr, exit_code, timed_out, timeout_message).
+    Returns (stdout, stderr, interleaved, exit_code, timed_out, timeout_message).
     """
     stderr_target = subprocess.PIPE if capture_stderr else subprocess.DEVNULL
 
@@ -180,12 +211,9 @@ async def stream_subprocess(
         command, *args, stdout=subprocess.PIPE, stderr=stderr_target, env=env
     )
 
-    stdout_chunks = []
-    stderr_chunks = []
-    current_stdout_size = 0
-    current_stderr_size = 0
-    stdout_truncated = False
-    stderr_truncated = False
+    stdout_buffer = StreamBuffer(MAX_OUTPUT_SIZE, "Output")
+    stderr_buffer = StreamBuffer(MAX_OUTPUT_SIZE, "Error")
+    interleaved_buffer = StreamBuffer(MAX_OUTPUT_SIZE, "Combined")
 
     logger = StreamLogger(node, source=source)
     start_time = time.monotonic()
@@ -201,11 +229,6 @@ async def stream_subprocess(
     )
 
     async def read_stream(stream, is_stderr):
-        nonlocal \
-            current_stdout_size, \
-            current_stderr_size, \
-            stdout_truncated, \
-            stderr_truncated
         while True:
             try:
                 chunk = await stream.read(1024)
@@ -217,28 +240,12 @@ async def stream_subprocess(
             monitor.update_activity()
             decoded = _clean_chunk(chunk)
             if decoded:
+                interleaved_buffer.append(decoded)
                 if not is_stderr:
                     logger.process_chunk(decoded)
-
-                    if not stdout_truncated and current_stdout_size < MAX_OUTPUT_SIZE:
-                        stdout_chunks.append(decoded)
-                        current_stdout_size += len(decoded)
-                        if current_stdout_size >= MAX_OUTPUT_SIZE:
-                            full_output_temp = "".join(stdout_chunks)
-                            stdout_chunks.clear()
-                            stdout_chunks.append(full_output_temp[:MAX_OUTPUT_SIZE])
-                            stdout_chunks.append("\n[... Output Truncated ...]")
-                            stdout_truncated = True
+                    stdout_buffer.append(decoded)
                 else:
-                    if not stderr_truncated and current_stderr_size < MAX_OUTPUT_SIZE:
-                        stderr_chunks.append(decoded)
-                        current_stderr_size += len(decoded)
-                        if current_stderr_size >= MAX_OUTPUT_SIZE:
-                            full_output_temp = "".join(stderr_chunks)
-                            stderr_chunks.clear()
-                            stderr_chunks.append(full_output_temp[:MAX_OUTPUT_SIZE])
-                            stderr_chunks.append("\n[... Output Truncated ...]")
-                            stderr_truncated = True
+                    stderr_buffer.append(decoded)
 
     read_stdout_task = asyncio.create_task(read_stream(process.stdout, False))
     read_stderr_task = None
@@ -289,15 +296,23 @@ async def stream_subprocess(
 
         logger.flush()
 
-    stdout = "".join(stdout_chunks)
-    stderr = "".join(stderr_chunks)
+    stdout = stdout_buffer.get_content()
+    stderr = stderr_buffer.get_content()
+    interleaved = interleaved_buffer.get_content()
 
     if monitor.timed_out:
         exit_code = -1
     else:
         exit_code = process.returncode if process.returncode is not None else 0
 
-    return stdout, stderr, exit_code, monitor.timed_out, monitor.timeout_message
+    return (
+        stdout,
+        stderr,
+        interleaved,
+        exit_code,
+        monitor.timed_out,
+        monitor.timeout_message,
+    )
 
 
 async def run_command(
@@ -339,7 +354,14 @@ async def run_command(
     async def on_timeout(msg):
         timeout_msg_list.append(msg)
 
-    stdout, stderr, exit_code, timed_out, timeout_message = await stream_subprocess(
+    (
+        stdout,
+        stderr,
+        interleaved,
+        exit_code,
+        timed_out,
+        timeout_message,
+    ) = await stream_subprocess(
         command,
         args,
         env,
@@ -351,8 +373,8 @@ async def run_command(
         source=source,
     )
 
-    # Combine stdout and stderr for backward compatibility
-    full_output = stdout + stderr
+    # Use interleaved output for backward compatibility
+    full_output = interleaved
     final_exit_code = exit_code
 
     if timed_out:

--- a/test/engine/test_gemini.py
+++ b/test/engine/test_gemini.py
@@ -11,7 +11,7 @@ async def test_gemini_engine_invoke():
     with patch(
         "copium_loop.engine.gemini.stream_subprocess", new_callable=AsyncMock
     ) as mock_stream:
-        mock_stream.return_value = ("mocked response", "", 0, False, "")
+        mock_stream.return_value = ("mocked response", "", "", 0, False, "")
         engine = GeminiEngine()
         response = await engine.invoke("hello", verbose=True, node="test_node")
 

--- a/test/engine/test_gemini_issue249.py
+++ b/test/engine/test_gemini_issue249.py
@@ -14,8 +14,15 @@ async def test_gemini_engine_filters_stderr_on_success():
     with patch(
         "copium_loop.engine.gemini.stream_subprocess", new_callable=AsyncMock
     ) as mock_stream:
-        # Mock returns (stdout, stderr, exit_code, timed_out, timeout_message)
-        mock_stream.return_value = ("clean response", "noisy warning", 0, False, "")
+        # Mock returns (stdout, stderr, interleaved, exit_code, timed_out, timeout_message)
+        mock_stream.return_value = (
+            "clean response",
+            "noisy warning",
+            "clean responsenoisy warning",
+            0,
+            False,
+            "",
+        )
 
         engine = GeminiEngine()
         response = await engine.invoke("hello", node="test_node")
@@ -33,7 +40,14 @@ async def test_gemini_engine_includes_stderr_on_failure():
     with patch(
         "copium_loop.engine.gemini.stream_subprocess", new_callable=AsyncMock
     ) as mock_stream:
-        mock_stream.return_value = ("stdout content", "stderr content", 1, False, "")
+        mock_stream.return_value = (
+            "stdout content",
+            "stderr content",
+            "interleaved content",
+            1,
+            False,
+            "",
+        )
 
         engine = GeminiEngine()
         with pytest.raises(Exception) as excinfo:

--- a/test/engine/test_jules.py
+++ b/test/engine/test_jules.py
@@ -508,7 +508,7 @@ async def test_jules_api_invoke_success():
     ):
         mock_pull.return_value = {"exit_code": 0, "output": ""}
         mock_push.return_value = {"exit_code": 0, "output": ""}
-        mock_stream.return_value = ("output", 0, False, "")
+        mock_stream.return_value = ("output", "", "output", 0, False, "")
         client = AsyncMock()
         mock_client.return_value.__aenter__.return_value = client
 
@@ -569,7 +569,7 @@ async def test_jules_api_invoke_success_200():
     ):
         mock_pull.return_value = {"exit_code": 0, "output": ""}
         mock_push.return_value = {"exit_code": 0, "output": ""}
-        mock_stream.return_value = ("output", 0, False, "")
+        mock_stream.return_value = ("output", "", "output", 0, False, "")
         client = AsyncMock()
         mock_client.return_value.__aenter__.return_value = client
 
@@ -686,7 +686,7 @@ async def test_jules_api_polling_retries():
     ):
         mock_pull.return_value = {"exit_code": 0, "output": ""}
         mock_push.return_value = {"exit_code": 0, "output": ""}
-        mock_stream.return_value = ("output", 0, False, "")
+        mock_stream.return_value = ("output", "", "output", 0, False, "")
         client = AsyncMock()
         mock_client.return_value.__aenter__.return_value = client
 
@@ -918,7 +918,7 @@ async def test_jules_api_pull_failure():
         ) as mock_stream,
     ):
         mock_push.return_value = {"exit_code": 0, "output": ""}
-        mock_stream.return_value = ("output", 0, False, "")
+        mock_stream.return_value = ("output", "", "output", 0, False, "")
         client = AsyncMock()
         mock_client.return_value.__aenter__.return_value = client
 

--- a/test/nodes/test_issue249_reproduction.py
+++ b/test/nodes/test_issue249_reproduction.py
@@ -40,7 +40,14 @@ async def test_issue249_integration_noise_reduction():
         "copium_loop.engine.gemini.stream_subprocess", new_callable=AsyncMock
     ) as mock_stream:
         # Architect call
-        mock_stream.return_value = (architect_stdout, architect_stderr, 0, False, "")
+        mock_stream.return_value = (
+            architect_stdout,
+            architect_stderr,
+            f"{architect_stdout}\n{architect_stderr}",
+            0,
+            False,
+            "",
+        )
 
         # 3. Run ArchitectNode
         # We need to mock get_diff because ArchitectNode calls get_architect_prompt which calls get_diff
@@ -67,7 +74,7 @@ async def test_issue249_integration_noise_reduction():
 
         # 5. Mock stream_subprocess for CoderNode call
         coder_stdout = "Implementing feature X with better modularity..."
-        mock_stream.return_value = (coder_stdout, "", 0, False, "")
+        mock_stream.return_value = (coder_stdout, "", coder_stdout, 0, False, "")
 
         # 6. Run CoderNode and capture the prompt passed to engine.invoke
         with patch.object(engine, "invoke", wraps=engine.invoke) as spy_invoke:

--- a/test/test_gemini.py
+++ b/test/test_gemini.py
@@ -17,7 +17,7 @@ class TestExecuteGemini:
         with patch(
             "copium_loop.engine.gemini.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
-            mock_stream.return_value = ("", "", 0, False, "")
+            mock_stream.return_value = ("", "", "", 0, False, "")
 
             engine = GeminiEngine()
             await engine._execute_gemini("test prompt", "test-model")
@@ -42,7 +42,7 @@ class TestExecuteGemini:
         with patch(
             "copium_loop.engine.gemini.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
-            mock_stream.return_value = ("", "", 0, False, "")
+            mock_stream.return_value = ("", "", "", 0, False, "")
 
             engine = GeminiEngine()
             await engine._execute_gemini("test prompt", None)

--- a/test/test_shell_stream_buffer.py
+++ b/test/test_shell_stream_buffer.py
@@ -1,0 +1,61 @@
+import os
+import sys
+
+import pytest
+
+from copium_loop.shell import StreamBuffer, stream_subprocess
+
+
+def test_stream_buffer_truncation():
+    limit = 10
+    buffer = StreamBuffer(limit, "Test")
+    buffer.append("12345")
+    assert buffer.get_content() == "12345"
+    assert not buffer.truncated
+
+    buffer.append("67890")
+    # Exactly limit, should NOT be truncated yet.
+    assert buffer.get_content() == "1234567890"
+
+    buffer.append("!")
+    assert buffer.truncated
+    assert buffer.get_content() == "1234567890\n[... Test Truncated ...]\n"
+
+    buffer.append("more")
+    # Should not add more
+    assert buffer.get_content() == "1234567890\n[... Test Truncated ...]\n"
+
+
+@pytest.mark.asyncio
+async def test_stream_subprocess_interleaving():
+    # A script that writes to stdout then stderr then stdout
+    script = "import sys; import time; sys.stdout.write('out1\\n'); sys.stdout.flush(); time.sleep(0.05); sys.stderr.write('err1\\n'); sys.stderr.flush(); time.sleep(0.05); sys.stdout.write('out2\\n'); sys.stdout.flush()"
+    command = sys.executable
+    args = ["-c", script]
+    env = os.environ.copy()
+
+    # Expecting 6-tuple: (stdout, stderr, interleaved, exit_code, timed_out, timeout_message)
+    result = await stream_subprocess(
+        command, args, env, node=None, command_timeout=10, capture_stderr=True
+    )
+
+    assert len(result) == 6
+    stdout, stderr, interleaved, exit_code, timed_out, timeout_message = result
+
+    assert "out1" in stdout
+    assert "out2" in stdout
+    assert "err1" not in stdout
+
+    assert "err1" in stderr
+    assert "out1" not in stderr
+
+    # Interleaved should have both in order
+    assert "out1" in interleaved
+    assert "err1" in interleaved
+    assert "out2" in interleaved
+
+    out1_idx = interleaved.find("out1")
+    err1_idx = interleaved.find("err1")
+    out2_idx = interleaved.find("out2")
+
+    assert out1_idx < err1_idx < out2_idx


### PR DESCRIPTION
- **feat: separate stdout and stderr in stream_subprocess to filter noise from LLM responses (issue #249)**
- **refactor: use StreamBuffer and preserve interleaving in stream_subprocess (issue #249)**

Closes https://github.com/gfxblit/copium-loop/issues/249