### PR TITLE
🎨 Palette: Add visual keyboard shortcut hints to session widgets

### DIFF
--- a/src/copium_loop/ui/textual_dashboard.py
+++ b/src/copium_loop/ui/textual_dashboard.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import re
 from pathlib import Path
 
 from rich.text import Text
@@ -182,16 +183,16 @@ class TextualDashboard(App):
 
             if current_sids == visible_sids and not has_empty_label:
                 # Just refresh existing
-                for widget in current_widgets:
+                for i, widget in enumerate(current_widgets):
+                    widget.index = i + 1
                     await widget.refresh_ui()
             else:
                 # Rebuild
                 await container.remove_children()
-                import re
 
-                for session in visible_sessions:
+                for i, session in enumerate(visible_sessions):
                     safe_sid = re.sub(r"[^a-zA-Z0-9_\-]", "_", session.session_id)
-                    w = SessionWidget(session, id=f"session-{safe_sid}")
+                    w = SessionWidget(session, index=i + 1, id=f"session-{safe_sid}")
                     await container.mount(w)
                     await w.refresh_ui()
 

--- a/src/copium_loop/ui/widgets/session.py
+++ b/src/copium_loop/ui/widgets/session.py
@@ -40,10 +40,13 @@ class SessionWidget(Vertical):
     }
     """
 
-    def __init__(self, session_column: SessionColumn, **kwargs):
+    def __init__(
+        self, session_column: SessionColumn, index: int | None = None, **kwargs
+    ):
         super().__init__(**kwargs)
         self.can_focus = True
         self.session_column = session_column
+        self.index = index
         self.session_id = session_column.session_id
         # We don't pre-populate self.pillars here because they need to be mounted in compose or refresh_ui
         self.pillars: dict[str, PillarWidget] = {}
@@ -91,7 +94,11 @@ class SessionWidget(Vertical):
             header.styles.color = header_color
 
             display_name = self.session_column.display_name
-            header.update(f"{display_name}{status_suffix}")
+            prefix = ""
+            if self.index is not None and 1 <= self.index <= 9:
+                prefix = f"[{self.index}] "
+
+            header.update(f"{prefix}{display_name}{status_suffix}")
             header.border_subtitle = ""
 
             container = self.query_one(f"#pillars-container-{self.safe_id}", Vertical)

--- a/test/ui/test_session_widget.py
+++ b/test/ui/test_session_widget.py
@@ -171,3 +171,45 @@ async def test_session_widget_handles_no_prefix():
         rendered = str(header.render())
 
         assert "simple-branch" in rendered
+
+
+@pytest.mark.asyncio
+async def test_session_widget_index_display():
+    """Test that SessionWidget correctly displays the index shortcut."""
+    col = SessionColumn("test-session")
+
+    # We need to manually initialize since our mock app doesn't support index argument yet
+    # or better, just create the widget and test its refresh logic
+
+    app = SessionWidgetMockApp(col)
+    async with app.run_test():
+        widget = app.query_one(SessionWidget)
+
+        # Test valid index
+        widget.index = 1
+        await widget.refresh_ui()
+        header = widget.query_one(f"#header-{widget.safe_id}", Static)
+        rendered = str(header.render())
+        assert "[1]" in rendered
+        assert "test-session" in rendered
+
+        # Test another valid index
+        widget.index = 9
+        await widget.refresh_ui()
+        header = widget.query_one(f"#header-{widget.safe_id}", Static)
+        rendered = str(header.render())
+        assert "[9]" in rendered
+
+        # Test invalid index (should not show)
+        widget.index = 10
+        await widget.refresh_ui()
+        header = widget.query_one(f"#header-{widget.safe_id}", Static)
+        rendered = str(header.render())
+        assert "[10]" not in rendered
+
+        # Test None index
+        widget.index = None
+        await widget.refresh_ui()
+        header = widget.query_one(f"#header-{widget.safe_id}", Static)
+        rendered = str(header.render())
+        assert "[" not in rendered or "[1]" not in rendered


### PR DESCRIPTION
💡 What: Added visual `[1]`, `[2]`, etc., hints to the session headers in the dashboard.
🎯 Why: To make the existing 1-9 keyboard shortcuts for switching tmux sessions visible and discoverable.
♿ Accessibility: Improves usability by making invisible shortcuts explicit.
📸 Before/After: Session headers now start with `[1] my-session` instead of `my-session`.

---
*PR created automatically by Jules for task [15053104224432104521](https://jules.google.com/task/15053104224432104521) started by @gfxblit*