### PR TITLE
feat: add gemini-3-pro-preview fallback and stats attribution

### DIFF
--- a/src/copium_loop/constants.py
+++ b/src/copium_loop/constants.py
@@ -3,6 +3,7 @@
 # fallbacks.
 MODELS = [
     "gemini-3.1-pro-preview",
+    "gemini-3-pro-preview",
     "gemini-3-flash-preview",
 ]
 

--- a/src/copium_loop/gemini_stats.py
+++ b/src/copium_loop/gemini_stats.py
@@ -154,7 +154,11 @@ class GeminiStatsClient:
         }
 
         # Pro models in priority order
-        for model in ["gemini-3.1-pro-preview", "gemini-2.5-pro"]:
+        for model in [
+            "gemini-3.1-pro-preview",
+            "gemini-3-pro-preview",
+            "gemini-2.5-pro",
+        ]:
             pro_match = re.search(
                 rf"{model}\s+(?:-|\d+)\s+([\d\.]+)%\s+resets in\s+([^│\n\r]+)",
                 output,

--- a/test/test_gemini_stats.py
+++ b/test/test_gemini_stats.py
@@ -174,6 +174,16 @@ class TestGeminiStatsClient(unittest.IsolatedAsyncioTestCase):
         self.assertAlmostEqual(usage["flash"], 30.0)
         self.assertEqual(usage["reset_flash"], "30m")
 
+    def test_parse_output_gemini_3_pro(self):
+        stats_output = "gemini-3-pro-preview 0 85.0% resets in 4h 20m"
+        self.mock_fetcher.fetch.return_value = stats_output
+
+        usage = self.client.get_usage()
+        self.assertIsNotNone(usage)
+        # 85.0% remaining means 15.0% used.
+        self.assertAlmostEqual(usage["pro"], 15.0)
+        self.assertEqual(usage["reset_pro"], "4h 20m")
+
     def test_backward_compatibility(self):
         mock_tmux = MagicMock()
         client = GeminiStatsClient(session_name="test-session", tmux=mock_tmux)

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -28,6 +28,7 @@ def test_agent_state_has_architect_status():
 
 def test_models_defined():
     assert "gemini-3.1-pro-preview" in MODELS
+    assert "gemini-3-pro-preview" in MODELS
     assert "gemini-3-flash-preview" in MODELS
 
 


### PR DESCRIPTION
Update MODELS constant to include gemini-3-pro-preview as a fallback for gemini-3.1-pro-preview. Update GeminiStatsClient to attribute gemini-3-pro-preview usage to the shared pro quota. Add tests for fallback chain and stats parsing.

Closes https://github.com/gfxblit/copium-loop/issues/259