### PR TITLE
⚡ Bolt: Cache git branch lookups

### DIFF
--- a/src/copium_loop/git.py
+++ b/src/copium_loop/git.py
@@ -1,4 +1,10 @@
+import os
+import time
+
 from copium_loop.shell import run_command
+
+_BRANCH_CACHE: dict[tuple[str, str | None], tuple[float, str]] = {}
+CACHE_TTL = 1.0
 
 
 async def is_git_repo(node: str | None = None) -> bool:
@@ -11,10 +17,21 @@ async def is_git_repo(node: str | None = None) -> bool:
 
 async def get_current_branch(node: str | None = None) -> str:
     """Returns the current git branch name."""
+    cwd = os.getcwd()
+    key = (cwd, node)
+    now = time.time()
+
+    if key in _BRANCH_CACHE:
+        timestamp, branch = _BRANCH_CACHE[key]
+        if now - timestamp < CACHE_TTL:
+            return branch
+
     res = await run_command(
         "git", ["branch", "--show-current"], node=node, capture_stderr=False
     )
-    return res["output"].strip()
+    branch = res["output"].strip()
+    _BRANCH_CACHE[key] = (now, branch)
+    return branch
 
 
 async def get_diff(


### PR DESCRIPTION
💡 What: Implemented a short-lived (1s) cache for `git branch --show-current` lookups.
🎯 Why: Frequent git subprocess calls were a potential bottleneck in the interactive agent loop.
📊 Impact: Reduces subprocess creation overhead for repeated branch checks within the TTL.
🔬 Measurement: Verified with a new test case `test_get_current_branch_caching` which asserts that `run_command` is called only once for multiple calls within the TTL.


---
*PR created automatically by Jules for task [16063598520734848150](https://jules.google.com/task/16063598520734848150) started by @gfxblit*