### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix prompt injection via git diff

### DIFF
--- a/src/copium_loop/nodes/architect_node.py
+++ b/src/copium_loop/nodes/architect_node.py
@@ -25,7 +25,7 @@ async def architect_node(state: AgentState) -> dict:
     engine = state["engine"]
     retry_count = state.get("retry_count", 0)
 
-    system_prompt = await get_architect_prompt(engine.engine_type, state)
+    system_prompt = await get_architect_prompt(engine.engine_type, state, engine)
 
     # Check for empty diff (Gemini provides diff in prompt, Jules calculates its own)
     if re.search(r"<git_diff>\s*</git_diff>", system_prompt, re.DOTALL):

--- a/src/copium_loop/nodes/reviewer_node.py
+++ b/src/copium_loop/nodes/reviewer_node.py
@@ -46,7 +46,7 @@ async def reviewer_node(state: AgentState) -> dict:
             "last_error": error_msg,
         }
 
-    system_prompt = await get_reviewer_prompt(engine.engine_type, state)
+    system_prompt = await get_reviewer_prompt(engine.engine_type, state, engine)
 
     # Check for empty diff
     if re.search(r"<git_diff>\s*</git_diff>", system_prompt, re.DOTALL):

--- a/src/copium_loop/nodes/utils.py
+++ b/src/copium_loop/nodes/utils.py
@@ -145,7 +145,7 @@ def node_header(
     return decorator
 
 
-async def get_architect_prompt(engine_type: str, state: dict) -> str:
+async def get_architect_prompt(engine_type: str, state: dict, engine) -> str:
     """Generates the architect system prompt based on engine type."""
     initial_commit_hash = state.get("initial_commit_hash", "")
     if not initial_commit_hash:
@@ -198,7 +198,7 @@ async def get_architect_prompt(engine_type: str, state: dict) -> str:
     if initial_commit_hash and await is_git_repo(node="architect"):
         git_diff = await get_diff(initial_commit_hash, head=None, node="architect")
 
-    safe_git_diff = git_diff  # We assume engine handles sanitization if needed, or we can sanitize here
+    safe_git_diff = engine.sanitize_for_prompt(git_diff)
 
     return f"""You are a software architect. Your task is to evaluate the code changes for architectural integrity.
 
@@ -226,7 +226,7 @@ async def get_architect_prompt(engine_type: str, state: dict) -> str:
     determine the final status. Do not make any fixes or changes yourself; rely entirely on the 'architect' skill's output."""
 
 
-async def get_reviewer_prompt(engine_type: str, state: dict) -> str:
+async def get_reviewer_prompt(engine_type: str, state: dict, engine) -> str:
     """Generates the reviewer system prompt based on engine type."""
     initial_commit_hash = state.get("initial_commit_hash", "")
     if not initial_commit_hash:
@@ -280,7 +280,7 @@ async def get_reviewer_prompt(engine_type: str, state: dict) -> str:
     if initial_commit_hash and await is_git_repo(node="reviewer"):
         git_diff = await get_diff(initial_commit_hash, head=None, node="reviewer")
 
-    safe_git_diff = git_diff
+    safe_git_diff = engine.sanitize_for_prompt(git_diff)
 
     return f"""You are a senior reviewer. Your task is to review the implementation provided by the current branch.
 

--- a/test/nodes/test_architect.py
+++ b/test/nodes/test_architect.py
@@ -230,9 +230,11 @@ class TestArchitectNode:
 async def test_jules_architect_prompt_robustness(agent_state):
     """Verify that the Jules architect prompt requires a SUMMARY and specific format."""
     agent_state["initial_commit_hash"] = "sha123"
+    engine = agent_state["engine"]
+    engine.sanitize_for_prompt.side_effect = lambda x: x
 
     with patch("copium_loop.nodes.utils.is_git_repo", return_value=True):
-        prompt = await get_architect_prompt("jules", agent_state)
+        prompt = await get_architect_prompt("jules", agent_state, engine)
 
         # New requirements from Issue #170
         assert "SUMMARY: [Your detailed analysis here]" in prompt

--- a/test/nodes/test_utils.py
+++ b/test/nodes/test_utils.py
@@ -315,8 +315,10 @@ class TestPromptsExtended:
     @patch.object(utils_module, "is_git_repo", new_callable=AsyncMock)
     @patch.object(utils_module, "get_diff", new_callable=AsyncMock)
     async def test_get_architect_prompt_jules(self, _mock_get_diff, _mock_is_git):
+        engine = MagicMock()
+        engine.sanitize_for_prompt.side_effect = lambda x: x
         state = {"initial_commit_hash": "abc"}
-        prompt = await utils.get_architect_prompt("jules", state)
+        prompt = await utils.get_architect_prompt("jules", state, engine)
         assert "You are a senior software architect" in prompt
         assert "VERDICT: APPROVED" in prompt
 
@@ -325,21 +327,26 @@ class TestPromptsExtended:
     async def test_get_architect_prompt_gemini(self, mock_get_diff, mock_is_git):
         mock_is_git.return_value = True
         mock_get_diff.return_value = "some diff"
+        engine = MagicMock()
+        engine.sanitize_for_prompt.side_effect = lambda x: x
         state = {"initial_commit_hash": "abc"}
-        prompt = await utils.get_architect_prompt("gemini", state)
+        prompt = await utils.get_architect_prompt("gemini", state, engine)
         assert "You are a software architect" in prompt
         assert "some diff" in prompt
         assert "VERDICT: APPROVED" in prompt
 
     async def test_get_architect_prompt_missing_hash(self):
+        engine = MagicMock()
         with pytest.raises(ValueError, match="Missing initial commit hash"):
-            await utils.get_architect_prompt("jules", {})
+            await utils.get_architect_prompt("jules", {}, engine)
 
     @patch.object(utils_module, "is_git_repo", new_callable=AsyncMock)
     @patch.object(utils_module, "get_diff", new_callable=AsyncMock)
     async def test_get_reviewer_prompt_jules(self, _mock_get_diff, _mock_is_git):
+        engine = MagicMock()
+        engine.sanitize_for_prompt.side_effect = lambda x: x
         state = {"initial_commit_hash": "abc"}
-        prompt = await utils.get_reviewer_prompt("jules", state)
+        prompt = await utils.get_reviewer_prompt("jules", state, engine)
         assert "You are a Principal Software Engineer" in prompt
         assert "VERDICT: APPROVED" in prompt
 
@@ -348,25 +355,30 @@ class TestPromptsExtended:
     async def test_get_reviewer_prompt_gemini(self, mock_get_diff, mock_is_git):
         mock_is_git.return_value = True
         mock_get_diff.return_value = "some diff"
+        engine = MagicMock()
+        engine.sanitize_for_prompt.side_effect = lambda x: x
         state = {"initial_commit_hash": "abc"}
-        prompt = await utils.get_reviewer_prompt("gemini", state)
+        prompt = await utils.get_reviewer_prompt("gemini", state, engine)
         assert "You are a senior reviewer" in prompt
         assert "some diff" in prompt
         assert "VERDICT: APPROVED" in prompt
 
     async def test_get_reviewer_prompt_missing_hash(self):
+        engine = MagicMock()
         with pytest.raises(ValueError, match="Missing initial commit hash"):
-            await utils.get_reviewer_prompt("jules", {})
+            await utils.get_reviewer_prompt("jules", {}, engine)
 
 
 @pytest.mark.asyncio
 async def test_get_architect_prompt_legacy(agent_state):
     """Verify architect prompt generation for different engines."""
     agent_state["initial_commit_hash"] = "sha123"
+    engine = agent_state["engine"]
+    engine.sanitize_for_prompt.side_effect = lambda x: x
 
     # Test Jules prompt
     with patch("copium_loop.nodes.utils.is_git_repo", return_value=True):
-        jules_prompt = await utils.get_architect_prompt("jules", agent_state)
+        jules_prompt = await utils.get_architect_prompt("jules", agent_state, engine)
         assert "sha123" in jules_prompt
         assert "git diff" in jules_prompt.lower()
         assert "JULES_OUTPUT.txt" not in jules_prompt
@@ -378,7 +390,7 @@ async def test_get_architect_prompt_legacy(agent_state):
             "copium_loop.nodes.utils.get_diff", return_value="some diff"
         ) as mock_get_diff,
     ):
-        gemini_prompt = await utils.get_architect_prompt("gemini", agent_state)
+        gemini_prompt = await utils.get_architect_prompt("gemini", agent_state, engine)
         assert "some diff" in gemini_prompt
         mock_get_diff.assert_called_with("sha123", head=None, node="architect")
 
@@ -388,10 +400,12 @@ async def test_get_reviewer_prompt_legacy(agent_state):
     """Verify reviewer prompt generation for different engines."""
     agent_state["initial_commit_hash"] = "sha123"
     agent_state["test_output"] = "PASS"
+    engine = agent_state["engine"]
+    engine.sanitize_for_prompt.side_effect = lambda x: x
 
     # Test Jules prompt
     with patch("copium_loop.nodes.utils.is_git_repo", return_value=True):
-        jules_prompt = await utils.get_reviewer_prompt("jules", agent_state)
+        jules_prompt = await utils.get_reviewer_prompt("jules", agent_state, engine)
         assert "sha123" in jules_prompt
         assert "git diff" in jules_prompt.lower()
         assert "JULES_OUTPUT.txt" not in jules_prompt
@@ -403,7 +417,7 @@ async def test_get_reviewer_prompt_legacy(agent_state):
             "copium_loop.nodes.utils.get_diff", return_value="some diff"
         ) as mock_get_diff,
     ):
-        gemini_prompt = await utils.get_reviewer_prompt("gemini", agent_state)
+        gemini_prompt = await utils.get_reviewer_prompt("gemini", agent_state, engine)
         assert "some diff" in gemini_prompt
         mock_get_diff.assert_called_with("sha123", head=None, node="reviewer")
 
@@ -459,13 +473,17 @@ async def test_reviewer_node_engine_agnostic(agent_state):
 @pytest.mark.asyncio
 class TestConvergencePrompts:
     async def test_architect_prompt_contains_head_hash_from_state(self):
+        engine = MagicMock()
+        engine.sanitize_for_prompt.side_effect = lambda x: x
         state = {"initial_commit_hash": "abc", "head_hash": "deadbeef"}
-        prompt = await utils.get_architect_prompt("jules", state)
+        prompt = await utils.get_architect_prompt("jules", state, engine)
         assert "(Current HEAD: deadbeef)" in prompt
 
     async def test_reviewer_prompt_contains_head_hash_from_state(self):
+        engine = MagicMock()
+        engine.sanitize_for_prompt.side_effect = lambda x: x
         state = {"initial_commit_hash": "abc", "head_hash": "deadbeef"}
-        prompt = await utils.get_reviewer_prompt("jules", state)
+        prompt = await utils.get_reviewer_prompt("jules", state, engine)
         assert "(Current HEAD: deadbeef)" in prompt
 
     async def test_coder_prompt_contains_head_hash_from_state(self):


### PR DESCRIPTION
Sentinel 🛡️ identified and fixed a high-priority prompt injection vulnerability.

**Vulnerability:**
The `git diff` output was being inserted directly into the system prompts for the Architect and Reviewer agents without sanitization. An attacker could potentially inject malicious instructions by committing a file containing the closing tag `</git_diff>` followed by prompt injection commands.

**Fix:**
We now use the `engine.sanitize_for_prompt()` method (which replaces `</git_diff>` with `[/git_diff]`) on the git diff content before constructing the prompt. This ensures the LLM treats the diff strictly as data.

**Verification:**
- Validated with a reproduction script that simulated a malicious diff.
- Updated and ran all unit tests to ensure no regressions.


---
*PR created automatically by Jules for task [940458520137195773](https://jules.google.com/task/940458520137195773) started by @gfxblit*