### PR TITLE
refactor: remove initial auto model selection from agent nodes

### DIFF
--- a/src/copium_loop/nodes/coder_node.py
+++ b/src/copium_loop/nodes/coder_node.py
@@ -13,12 +13,10 @@ async def coder_node(state: AgentState) -> dict:
     engine = state["engine"]
     system_prompt = await get_coder_prompt(engine.engine_type, state, engine)
 
-    # Start with "auto" (None), then fallback to default models
-    coder_models = [None] + MODELS
     code_content = await engine.invoke(
         system_prompt,
         ["--yolo"],
-        models=coder_models,
+        models=MODELS,
         verbose=state.get("verbose"),
         label="Coder System",
         node="coder",

--- a/src/copium_loop/nodes/journaler_node.py
+++ b/src/copium_loop/nodes/journaler_node.py
@@ -71,16 +71,14 @@ async def journaler_node(state: AgentState) -> dict:
 
     Output ONLY the project lesson or "NO_LESSON"."""
 
-        models = [None] + MODELS
         lesson = await engine.invoke(
             prompt,
             ["--yolo"],
-            models=models,
+            models=MODELS,
             verbose=state.get("verbose"),
             label="Journaler System",
             node="journaler",
         )
-
         lesson = lesson.strip().strip('"').strip("'")
 
         review_status = state.get("review_status", "pending")


### PR DESCRIPTION
Agent nodes (coder and journaler) now directly use the recommended
model priority list (MODELS) instead of starting with 'auto' (None).
This ensures consistent behavior and follows the recommended model
selection fallback loop.

Closes #267

Closes https://github.com/gfxblit/copium-loop/issues/267