### PR TITLE
feat: increase MAX_RETRIES to 30 (#269)

### DIFF
--- a/src/copium_loop/constants.py
+++ b/src/copium_loop/constants.py
@@ -22,7 +22,7 @@ VALID_NODES = [
 LEAN_NODES = {"tester", "pr_pre_checker", "pr_creator"}
 
 # Max retries for the workflow
-MAX_RETRIES = 10
+MAX_RETRIES = 30
 
 # Inactivity timeout in seconds (10 minutes)
 INACTIVITY_TIMEOUT = 600

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -1,0 +1,6 @@
+from copium_loop import constants
+
+
+def test_max_retries_value():
+    """Verify that MAX_RETRIES is set to 30."""
+    assert constants.MAX_RETRIES == 30


### PR DESCRIPTION
Resolves issue #269 by increasing the max tries of the workflow loop from 10 to 30 to allow the agent to solve more complex problems.

Closes https://github.com/gfxblit/copium-loop/issues/269