### PR TITLE
🎨 Palette: Add keyboard shortcut index to session header

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-02-18 - Textual Empty States
 **Learning:** Textual containers render as blank space when empty, which can be confused for a frozen application.
 **Action:** When a main container has no children, always mount a dedicated `Label` or widget with a clear "Empty State" message and call-to-action.
+
+## 2026-03-01 - TUI Keyboard Shortcuts
+**Learning:** In TUI dashboards with dense information, keyboard shortcuts (like 1-9) are only discoverable if the UI explicitly labels the target elements with the corresponding number.
+**Action:** Always prepend the shortcut index (e.g., `[1]`) to the header of list items that can be selected via number keys.

--- a/src/copium_loop/ui/textual_dashboard.py
+++ b/src/copium_loop/ui/textual_dashboard.py
@@ -182,16 +182,17 @@ class TextualDashboard(App):
 
             if current_sids == visible_sids and not has_empty_label:
                 # Just refresh existing
-                for widget in current_widgets:
+                for i, widget in enumerate(current_widgets, start=1):
+                    widget.index = i
                     await widget.refresh_ui()
             else:
                 # Rebuild
                 await container.remove_children()
                 import re
 
-                for session in visible_sessions:
+                for i, session in enumerate(visible_sessions, start=1):
                     safe_sid = re.sub(r"[^a-zA-Z0-9_\-]", "_", session.session_id)
-                    w = SessionWidget(session, id=f"session-{safe_sid}")
+                    w = SessionWidget(session, index=i, id=f"session-{safe_sid}")
                     await container.mount(w)
                     await w.refresh_ui()
 

--- a/src/copium_loop/ui/widgets/session.py
+++ b/src/copium_loop/ui/widgets/session.py
@@ -40,9 +40,12 @@ class SessionWidget(Vertical):
     }
     """
 
-    def __init__(self, session_column: SessionColumn, **kwargs):
+    def __init__(
+        self, session_column: SessionColumn, index: int | None = None, **kwargs
+    ):
         super().__init__(**kwargs)
         self.can_focus = True
+        self.index = index
         self.session_column = session_column
         self.session_id = session_column.session_id
         # We don't pre-populate self.pillars here because they need to be mounted in compose or refresh_ui
@@ -91,6 +94,8 @@ class SessionWidget(Vertical):
             header.styles.color = header_color
 
             display_name = self.session_column.display_name
+            if self.index:
+                display_name = f"[{self.index}] {display_name}"
             header.update(f"{display_name}{status_suffix}")
             header.border_subtitle = ""
 

--- a/test/ui/test_session_widget.py
+++ b/test/ui/test_session_widget.py
@@ -10,13 +10,14 @@ from copium_loop.ui.widgets.session import SessionWidget
 
 
 class SessionWidgetMockApp(App):
-    def __init__(self, column=None):
+    def __init__(self, column=None, **kwargs):
         super().__init__()
         self.session_column = column or SessionColumn("test-session")
+        self.widget_kwargs = kwargs
         self.session_widget = None
 
     def compose(self) -> ComposeResult:
-        self.session_widget = SessionWidget(self.session_column)
+        self.session_widget = SessionWidget(self.session_column, **self.widget_kwargs)
         yield self.session_widget
 
 
@@ -171,3 +172,26 @@ async def test_session_widget_handles_no_prefix():
         rendered = str(header.render())
 
         assert "simple-branch" in rendered
+
+
+@pytest.mark.asyncio
+async def test_session_widget_displays_index():
+    # Setup with index=1
+    col = SessionColumn("test-session")
+    app = SessionWidgetMockApp(col, index=1)
+
+    async with app.run_test():
+        widget = app.query_one(SessionWidget)
+
+        # Initial check
+        await widget.refresh_ui()
+        header = widget.query_one(f"#header-{widget.safe_id}", Static)
+        rendered = str(header.render())
+
+        assert "[1] test-session" in rendered
+
+        # Update index
+        widget.index = 2
+        await widget.refresh_ui()
+        rendered = str(header.render())
+        assert "[2] test-session" in rendered


### PR DESCRIPTION
💡 **What:** Added a visual numeric index (e.g., `[1]`) to the header of each session in the TUI dashboard.
🎯 **Why:** Users can switch sessions using number keys (1-9), but previously had to guess which session corresponded to which number. This change makes the keyboard shortcuts discoverable and the interface more intuitive.
📸 **Before/After:** No screenshot (TUI), but tests verify the rendered text includes the index.
♿ **Accessibility:** Improves keyboard navigation discoverability.

---
*PR created automatically by Jules for task [7011123528858779680](https://jules.google.com/task/7011123528858779680) started by @gfxblit*