### PR TITLE
🎨 Palette: Add keyboard shortcut hints [1-9] to session headers

### DIFF
--- a/src/copium_loop/ui/textual_dashboard.py
+++ b/src/copium_loop/ui/textual_dashboard.py
@@ -182,16 +182,18 @@ class TextualDashboard(App):
 
             if current_sids == visible_sids and not has_empty_label:
                 # Just refresh existing
-                for widget in current_widgets:
+                for i, widget in enumerate(current_widgets, start=1):
+                    # Ensure index is updated
+                    widget.index = i
                     await widget.refresh_ui()
             else:
                 # Rebuild
                 await container.remove_children()
                 import re
 
-                for session in visible_sessions:
+                for i, session in enumerate(visible_sessions, start=1):
                     safe_sid = re.sub(r"[^a-zA-Z0-9_\-]", "_", session.session_id)
-                    w = SessionWidget(session, id=f"session-{safe_sid}")
+                    w = SessionWidget(session, index=i, id=f"session-{safe_sid}")
                     await container.mount(w)
                     await w.refresh_ui()
 

--- a/src/copium_loop/ui/widgets/session.py
+++ b/src/copium_loop/ui/widgets/session.py
@@ -40,8 +40,11 @@ class SessionWidget(Vertical):
     }
     """
 
-    def __init__(self, session_column: SessionColumn, **kwargs):
+    def __init__(
+        self, session_column: SessionColumn, index: int | None = None, **kwargs
+    ):
         super().__init__(**kwargs)
+        self.index = index
         self.can_focus = True
         self.session_column = session_column
         self.session_id = session_column.session_id
@@ -91,7 +94,8 @@ class SessionWidget(Vertical):
             header.styles.color = header_color
 
             display_name = self.session_column.display_name
-            header.update(f"{display_name}{status_suffix}")
+            prefix = f"[{self.index}] " if self.index is not None else ""
+            header.update(f"{prefix}{display_name}{status_suffix}")
             header.border_subtitle = ""
 
             container = self.query_one(f"#pillars-container-{self.safe_id}", Vertical)

--- a/test/ui/test_session_widget_index.py
+++ b/test/ui/test_session_widget_index.py
@@ -1,0 +1,61 @@
+import re
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from copium_loop.ui.column import SessionColumn
+from copium_loop.ui.widgets.session import SessionWidget
+
+
+class SessionWidgetIndexMockApp(App):
+    def __init__(self, column=None, index=None):
+        super().__init__()
+        self.session_column = column or SessionColumn("test-session")
+        self.index = index
+        self.session_widget = None
+
+    def compose(self) -> ComposeResult:
+        # Pass index if provided
+        kwargs = {}
+        if self.index is not None:
+            kwargs["index"] = self.index
+
+        self.session_widget = SessionWidget(self.session_column, **kwargs)
+        yield self.session_widget
+
+
+@pytest.mark.asyncio
+async def test_session_widget_with_index():
+    app = SessionWidgetIndexMockApp(index=1)
+    async with app.run_test() as pilot:
+        session_widget = app.query_one(SessionWidget)
+
+        # Trigger refresh
+        await session_widget.refresh_ui()
+        await pilot.pause()
+
+        header = session_widget.query_one(f"#header-{session_widget.safe_id}", Static)
+        rendered = str(header.render())
+
+        # Should contain the index prefix
+        assert "[1]" in rendered
+        assert "test-session" in rendered
+
+
+@pytest.mark.asyncio
+async def test_session_widget_without_index():
+    app = SessionWidgetIndexMockApp(index=None)
+    async with app.run_test() as pilot:
+        session_widget = app.query_one(SessionWidget)
+
+        # Trigger refresh
+        await session_widget.refresh_ui()
+        await pilot.pause()
+
+        header = session_widget.query_one(f"#header-{session_widget.safe_id}", Static)
+        rendered = str(header.render())
+
+        # Should NOT contain any bracketed number prefix at the start
+        assert not re.match(r"^\[\d+\]", rendered.strip())
+        assert "test-session" in rendered


### PR DESCRIPTION
🎨 Palette: Added keyboard shortcut hints to session headers

💡 **What:** Added `[1]`, `[2]`, etc., prefixes to session headers in the dashboard.
🎯 **Why:** Users can switch to tmux sessions using number keys (1-9), but this feature wasn't discoverable. The indices now explicitly map the list order to the shortcuts.
📸 **Visuals:** Headers now look like `[1] my-feature-branch` instead of just `my-feature-branch`.
♿ **Accessibility:** Reduces cognitive load by making navigation shortcuts explicit.

---
*PR created automatically by Jules for task [12625545893999438947](https://jules.google.com/task/12625545893999438947) started by @gfxblit*