### PR TITLE
🎨 Palette: Add keyboard shortcut hints to session headers

### DIFF
--- a/src/copium_loop/ui/textual_dashboard.py
+++ b/src/copium_loop/ui/textual_dashboard.py
@@ -182,16 +182,17 @@ class TextualDashboard(App):
 
             if current_sids == visible_sids and not has_empty_label:
                 # Just refresh existing
-                for widget in current_widgets:
+                for i, widget in enumerate(current_widgets):
+                    widget.index = i + 1
                     await widget.refresh_ui()
             else:
                 # Rebuild
                 await container.remove_children()
                 import re
 
-                for session in visible_sessions:
+                for i, session in enumerate(visible_sessions):
                     safe_sid = re.sub(r"[^a-zA-Z0-9_\-]", "_", session.session_id)
-                    w = SessionWidget(session, id=f"session-{safe_sid}")
+                    w = SessionWidget(session, index=i + 1, id=f"session-{safe_sid}")
                     await container.mount(w)
                     await w.refresh_ui()
 

--- a/src/copium_loop/ui/widgets/session.py
+++ b/src/copium_loop/ui/widgets/session.py
@@ -40,11 +40,14 @@ class SessionWidget(Vertical):
     }
     """
 
-    def __init__(self, session_column: SessionColumn, **kwargs):
+    def __init__(
+        self, session_column: SessionColumn, index: int | None = None, **kwargs
+    ):
         super().__init__(**kwargs)
         self.can_focus = True
         self.session_column = session_column
         self.session_id = session_column.session_id
+        self.index = index
         # We don't pre-populate self.pillars here because they need to be mounted in compose or refresh_ui
         self.pillars: dict[str, PillarWidget] = {}
 
@@ -91,7 +94,11 @@ class SessionWidget(Vertical):
             header.styles.color = header_color
 
             display_name = self.session_column.display_name
-            header.update(f"{display_name}{status_suffix}")
+
+            # UX: Add index hint for keyboard shortcut (e.g. [1] my-branch)
+            prefix = f"[{self.index}] " if self.index is not None else ""
+
+            header.update(f"{prefix}{display_name}{status_suffix}")
             header.border_subtitle = ""
 
             container = self.query_one(f"#pillars-container-{self.safe_id}", Vertical)

--- a/test/ui/test_session_widget.py
+++ b/test/ui/test_session_widget.py
@@ -10,13 +10,14 @@ from copium_loop.ui.widgets.session import SessionWidget
 
 
 class SessionWidgetMockApp(App):
-    def __init__(self, column=None):
+    def __init__(self, column=None, **kwargs):
         super().__init__()
         self.session_column = column or SessionColumn("test-session")
         self.session_widget = None
+        self.widget_kwargs = kwargs
 
     def compose(self) -> ComposeResult:
-        self.session_widget = SessionWidget(self.session_column)
+        self.session_widget = SessionWidget(self.session_column, **self.widget_kwargs)
         yield self.session_widget
 
 
@@ -171,3 +172,19 @@ async def test_session_widget_handles_no_prefix():
         rendered = str(header.render())
 
         assert "simple-branch" in rendered
+
+
+@pytest.mark.asyncio
+async def test_session_widget_displays_index_shortcut():
+    # Setup with index 3
+    col = SessionColumn("my-branch")
+    app = SessionWidgetMockApp(col, index=3)
+
+    async with app.run_test():
+        widget = app.session_widget
+        await widget.refresh_ui()
+
+        header = widget.query_one(f"#header-{widget.safe_id}", Static)
+        rendered = str(header.render())
+
+        assert "[3] my-branch" in rendered


### PR DESCRIPTION
💡 What: Added an optional `index` property to `SessionWidget` that renders as a prefix `[index]` in the header. `TextualDashboard` now passes the 1-based index based on the session's position on the screen.
🎯 Why: While the dashboard supports pressing 1-9 to jump to the corresponding tmux session, this feature was completely hidden. Adding the visual hint makes the interface more intuitive and aids keyboard navigation discoverability.
📸 Before/After: Before `my-branch-name`, After `[1] my-branch-name`
♿ Accessibility: Improves cognitive accessibility by clearly labeling available keyboard interactions rather than relying on user memory or hidden documentation.

---
*PR created automatically by Jules for task [3402385773412651104](https://jules.google.com/task/3402385773412651104) started by @gfxblit*