### PR TITLE
🎨 Palette: Add keyboard shortcut hints to session headers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-02-18 - Textual Empty States
 **Learning:** Textual containers render as blank space when empty, which can be confused for a frozen application.
 **Action:** When a main container has no children, always mount a dedicated `Label` or widget with a clear "Empty State" message and call-to-action.
+## 2026-03-01 - Textual Keyboard Shortcuts
+**Learning:** Keyboard shortcuts 1-9 were bound to tmux switch actions, but there were no visual hints on the `SessionWidget` headers making them undiscoverable.
+**Action:** Add optional `index` parameter to list widgets and prepend `[index] ` to their display names to provide keyboard shortcut hints.

--- a/src/copium_loop/ui/textual_dashboard.py
+++ b/src/copium_loop/ui/textual_dashboard.py
@@ -182,16 +182,17 @@ class TextualDashboard(App):
 
             if current_sids == visible_sids and not has_empty_label:
                 # Just refresh existing
-                for widget in current_widgets:
+                for i, widget in enumerate(current_widgets):
+                    widget.index = i + 1
                     await widget.refresh_ui()
             else:
                 # Rebuild
                 await container.remove_children()
                 import re
 
-                for session in visible_sessions:
+                for i, session in enumerate(visible_sessions):
                     safe_sid = re.sub(r"[^a-zA-Z0-9_\-]", "_", session.session_id)
-                    w = SessionWidget(session, id=f"session-{safe_sid}")
+                    w = SessionWidget(session, index=i + 1, id=f"session-{safe_sid}")
                     await container.mount(w)
                     await w.refresh_ui()
 

--- a/src/copium_loop/ui/widgets/session.py
+++ b/src/copium_loop/ui/widgets/session.py
@@ -40,11 +40,14 @@ class SessionWidget(Vertical):
     }
     """
 
-    def __init__(self, session_column: SessionColumn, **kwargs):
+    def __init__(
+        self, session_column: SessionColumn, index: int | None = None, **kwargs
+    ):
         super().__init__(**kwargs)
         self.can_focus = True
         self.session_column = session_column
         self.session_id = session_column.session_id
+        self.index = index
         # We don't pre-populate self.pillars here because they need to be mounted in compose or refresh_ui
         self.pillars: dict[str, PillarWidget] = {}
 
@@ -91,7 +94,9 @@ class SessionWidget(Vertical):
             header.styles.color = header_color
 
             display_name = self.session_column.display_name
-            header.update(f"{display_name}{status_suffix}")
+
+            prefix = f"[{self.index}] " if self.index is not None else ""
+            header.update(f"{prefix}{display_name}{status_suffix}")
             header.border_subtitle = ""
 
             container = self.query_one(f"#pillars-container-{self.safe_id}", Vertical)

--- a/test/ui/test_session_widget.py
+++ b/test/ui/test_session_widget.py
@@ -10,14 +10,26 @@ from copium_loop.ui.widgets.session import SessionWidget
 
 
 class SessionWidgetMockApp(App):
-    def __init__(self, column=None):
+    def __init__(self, column=None, **kwargs):
         super().__init__()
         self.session_column = column or SessionColumn("test-session")
         self.session_widget = None
+        self.widget_kwargs = kwargs
 
     def compose(self) -> ComposeResult:
-        self.session_widget = SessionWidget(self.session_column)
+        self.session_widget = SessionWidget(self.session_column, **self.widget_kwargs)
         yield self.session_widget
+
+
+@pytest.mark.asyncio
+async def test_session_widget_keyboard_shortcut_hint():
+    app = SessionWidgetMockApp(index=1)
+    async with app.run_test():
+        session_widget = app.query_one(SessionWidget)
+        await session_widget.refresh_ui()
+
+        header = session_widget.query_one("#header-test-session", Static)
+        assert "[1] test-session" in str(header.render())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
💡 What: Added `[index] ` prefixes to the display names in the `SessionWidget` headers (e.g., `[1] branch-name`).
🎯 Why: The dashboard already supported keyboard shortcuts (`1` through `9`) to switch to the corresponding tmux session. However, there was no visual indicator of which session corresponded to which number, making the feature effectively hidden.
📸 Before/After: N/A
♿ Accessibility: Improves discoverability of existing keyboard navigation features.

---
*PR created automatically by Jules for task [17910217786563251199](https://jules.google.com/task/17910217786563251199) started by @gfxblit*